### PR TITLE
[Feat/Fix] Modal 분리 및 상세페이지, 직군 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.6.0",
     "@tanstack/react-table": "^8.19.3",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,16 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      name="description"
-      content="konkuk university student developer team project"
-    />
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="konkuk university student developer team project" />
 
-    <title>RoadMap KU</title>
-  </head>
-  <body>
-    <div id="root"></div>
-  </body>
+		<title>RoadMap KU</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<div id="modal"></div>
+	</body>
 </html>

--- a/src/components/CourseDetail/CourseDetailStyle.jsx
+++ b/src/components/CourseDetail/CourseDetailStyle.jsx
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+export const ScrollContainer = styled.div`
+	background-color: transparent;
+	width:300px
+	height:500px
+	padding: 0rem;
+	border-radius: 8px;
+	max-height: 80vh; /* 내용물의 최대 높이 설정 */
+	overflow-y: auto; /* 세로 스크롤바 표시 */
+`;
+
+export const Title = styled.h1`
+	background-color: #036b3f;
+	padding: 1rem;
+	border-radius: 8px;
+	color: white;
+	margin: 0;
+	font-size: 2rem;
+`;
+
+export const SubjectContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	margin-top: 1rem;
+`;
+
+export const Subject = styled.h1`
+	justify-content: center;
+	border-radius: 8px;
+	color: black;
+	margin: 0;
+	font-size: 1.7rem;
+	padding: 0.5rem;
+`;
+
+export const Subtitle = styled.h2`
+	color: #036b3f; /* main color */
+	font-size: 1.5rem;
+	margin: 0.5rem 0;
+	padding-top: 2rem;
+`;
+
+export const ModalContent = styled.div`
+	font-family: Arial;
+	font-size: 1rem;
+	margin: 10px 0;
+`;
+
+export const TableContent = styled.div`
+	font-family: Arial;
+	margin: 10px 0;
+`;

--- a/src/components/CourseDetail/CousreDetail.jsx
+++ b/src/components/CourseDetail/CousreDetail.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { courseDetailState } from '../../recoils/atoms';
+import {
+	Title,
+	Subtitle,
+	ModalContent,
+	Subject,
+	SubjectContainer,
+	TableContent,
+	ScrollContainer
+} from './CourseDetailStyle';
+import TableComponent from '../TableComponent';
+import TableComponent2 from '../TableComponent2';
+import Modal from '../Modal/Modal';
+
+function CourseDetail({ onClose }) {
+	// const courseDetail = useRecoilValue(courseDetailState);
+
+	// console.log('Course Detail:', courseDetail); // 데이터 확인
+	const [courseDetail, setCourseDetail] = useRecoilState(courseDetailState);
+	useEffect(() => {
+		fetch('/data/courseDetail.json')
+			.then((response) => response.json())
+			.then((data) => setCourseDetail(data))
+			.catch((error) => console.error('Error fetching course details:', error));
+	}, [setCourseDetail]);
+
+	console.log('Course Detail:', courseDetail); // 데이터 확인
+
+	const modalContent = courseDetail[1]; // 예시로 네 번째 데이터를 사용
+
+	console.log('modalContent :', modalContent);
+	if (!courseDetail.length)
+		return (
+			<Modal onClose={onClose}>
+				<div>Loading...</div>
+			</Modal>
+		); // 데이터가 없을 때 로딩 표시
+
+	const additionalInfo = modalContent.Addimfomation;
+
+	const tableData = [
+		['개설대학', additionalInfo.openingCollegeName],
+		['개설학과', additionalInfo.openingSubjectName],
+		['강의유형', additionalInfo.lectureType],
+		['학년', additionalInfo.openingSchoolYear.toString()],
+		['학기', additionalInfo.openingSemesterTerm],
+		['학점', additionalInfo.time.toString()],
+		['공학인증구분', additionalInfo.engineeringCertificationFlagCode === 0 ? 'N' : 'Y'],
+		['선수강과목', additionalInfo.preCourse],
+		['MOOC 여부', additionalInfo.moocFlag === 0 ? 'N' : 'Y'],
+		['Selc 여부', additionalInfo.selcFlag === 0 ? 'N' : 'Y'],
+		['챌린저여부', additionalInfo.dreamSemesterFlag === 0 ? 'N' : 'Y']
+	];
+
+	const tableData2 = [
+		[modalContent.competency.competencyName1, modalContent.competency.competencyRemark1],
+		[modalContent.competency.competencyName2, modalContent.competency.competencyRemark2],
+		[modalContent.competency.competencyName3, modalContent.competency.competencyRemark3]
+	];
+
+	return (
+		<Modal onClose={onClose}>
+			<ScrollContainer>
+				<Title>Course Information</Title>
+
+				<SubjectContainer>
+					<Subject>
+						{modalContent.typicalKoreanName} ({modalContent.typicalEnglishName})
+					</Subject>
+				</SubjectContainer>
+				<Subtitle>국문설명</Subtitle>
+				<ModalContent>{modalContent.koreanDescription}</ModalContent>
+				<Subtitle>영문설명</Subtitle>
+				<ModalContent>{modalContent.englishDescription}</ModalContent>
+				<Subtitle>Additional Information</Subtitle>
+				<TableContent>
+					<TableComponent data={tableData} />
+				</TableContent>
+				<Subtitle>전공 역량</Subtitle>
+				<TableContent>
+					<TableComponent2 data={tableData2} />
+				</TableContent>
+			</ScrollContainer>
+		</Modal>
+	);
+}
+
+export default CourseDetail;

--- a/src/components/FieldCategory.jsx
+++ b/src/components/FieldCategory.jsx
@@ -41,6 +41,7 @@ export const FixButton = styled.button`
 	&:hover {
 		background-color: #02472a;
 	}
+	margin-top: 2rem;
 `;
 
 const FieldCategory = () => {

--- a/src/components/FieldCategoryInput.jsx
+++ b/src/components/FieldCategoryInput.jsx
@@ -12,14 +12,15 @@ import useClient from '../hooks/useClient';
 import styled from 'styled-components';
 import { FixButton } from './FieldCategory';
 
+import Modal from './Modal/Modal';
+
 const Container = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	padding: 20px;
-	background-color: #f9f9f9;
+	background-color: white;
 	border-radius: 8px;
-	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 `;
 
 const StyledSelect = styled.select`
@@ -31,6 +32,7 @@ const StyledSelect = styled.select`
 	font-size: 16px;
 	background-color: #fff;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	margin-bottom: 1rem;
 
 	&:focus {
 		border-color: #007bff;
@@ -39,7 +41,13 @@ const StyledSelect = styled.select`
 	}
 `;
 
-const FieldCategoryInput = () => {
+export const Title = styled.h2`
+	color: #036b3f; /* main color */
+	font-size: 1.7rem;
+	margin: 1rem;
+	padding-bottom: 2rem;
+`;
+function FieldCategoryInput({ onClose }) {
 	const largeRef = useRef();
 	const middleRef = useRef();
 	const smallRef = useRef();
@@ -99,41 +107,44 @@ const FieldCategoryInput = () => {
 	};
 
 	return (
-		<Container>
-			<StyledSelect ref={largeRef} onChange={selectLargeField}>
-				{largeFields.map((item) => (
-					<option key={item.fieldCode} value={JSON.stringify(item)}>
-						{item.largeField}
-					</option>
-				))}
-			</StyledSelect>
-			<StyledSelect ref={middleRef} onChange={selectMiddleField} disabled={middleFields.length > 0 ? '' : 'disabled'}>
-				<option value="">분야를 선택해주세요</option>
-				{middleFields.map((item) => (
-					<option key={item.fieldCode} value={JSON.stringify(item)}>
-						{item.middleField}
-					</option>
-				))}
-			</StyledSelect>
-			<StyledSelect ref={smallRef} onChange={selectSmallField} disabled={smallFields.length > 0 ? '' : 'disabled'}>
-				<option value="">분야를 선택해주세요</option>
-				{smallFields.map((item) => (
-					<option key={item.fieldCode} value={JSON.stringify(item)}>
-						{item.smallField}
-					</option>
-				))}
-			</StyledSelect>
-			<StyledSelect ref={detailRef} disabled={detailFields.length > 0 ? '' : 'disabled'}>
-				<option value="">분야를 선택해주세요</option>
-				{detailFields.map((item) => (
-					<option key={item.fieldCode} value={JSON.stringify(item)}>
-						{item.detailField}
-					</option>
-				))}
-			</StyledSelect>
-			<FixButton onClick={submitHandler}>검색하기</FixButton>
-		</Container>
+		<Modal onClose={onClose}>
+			<Container>
+				<Title>직군을 선택해주세요</Title>
+				<StyledSelect ref={largeRef} onChange={selectLargeField}>
+					{largeFields.map((item) => (
+						<option key={item.fieldCode} value={JSON.stringify(item)}>
+							{item.largeField}
+						</option>
+					))}
+				</StyledSelect>
+				<StyledSelect ref={middleRef} onChange={selectMiddleField} disabled={middleFields.length > 0 ? '' : 'disabled'}>
+					<option value="">분야를 선택해주세요</option>
+					{middleFields.map((item) => (
+						<option key={item.fieldCode} value={JSON.stringify(item)}>
+							{item.middleField}
+						</option>
+					))}
+				</StyledSelect>
+				<StyledSelect ref={smallRef} onChange={selectSmallField} disabled={smallFields.length > 0 ? '' : 'disabled'}>
+					<option value="">분야를 선택해주세요</option>
+					{smallFields.map((item) => (
+						<option key={item.fieldCode} value={JSON.stringify(item)}>
+							{item.smallField}
+						</option>
+					))}
+				</StyledSelect>
+				<StyledSelect ref={detailRef} disabled={detailFields.length > 0 ? '' : 'disabled'}>
+					<option value="">분야를 선택해주세요</option>
+					{detailFields.map((item) => (
+						<option key={item.fieldCode} value={JSON.stringify(item)}>
+							{item.detailField}
+						</option>
+					))}
+				</StyledSelect>
+				<FixButton onClick={submitHandler}>검색하기</FixButton>
+			</Container>
+		</Modal>
 	);
-};
+}
 
 export default FieldCategoryInput;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,10 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import styled from 'styled-components';
-import Modal from './Modal/Modal'; // Modal 컴포넌트 임포트
+//import Modal from './Modal/Modal'; // Modal 컴포넌트 임포트
 import KuLogo from '../components/LogoFile/Kulogo';
+import CourseDetail from './CourseDetail/CousreDetail';
+import FieldCategoryInput from './FieldCategoryInput';
 
 const theme = {
 	active: {
@@ -71,12 +73,35 @@ const ExtraLink = styled.a`
 	}
 `;
 
+export const Button = styled.button`
+	background-color: #036b3f; /* main color */
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: white;
+	font-size: 0.875rem;
+	font-weight: normal;
+	border-radius: 0.375rem;
+	padding: 0.5rem 1.25rem;
+	transition: background-color 0.2s ease-in-out;
+	cursor: pointer;
+	&:hover {
+		background-color: #059669; /* darker green on hover */
+	}
+`;
+
 function Header() {
 	const navigate = useNavigate();
-	const [showModal, setShowModal] = useState(false);
-	const handleModalOpen = () => setShowModal(true);
-	const handleModalClose = () => setShowModal(false);
+	const [isOpen1, setIsOpen1] = useState(false);
+	const [isOpen2, setIsOpen2] = useState(false);
 	const { pathname } = useLocation();
+
+	const onClickButton1 = () => {
+		setIsOpen1(true);
+	};
+	const onClickButton2 = () => {
+		setIsOpen2(true);
+	};
 
 	return (
 		<>
@@ -91,12 +116,22 @@ function Header() {
 					<HeaderLink onClick={() => navigate('/road-map')} active={pathname === '/road-map'}>
 						로드맵
 					</HeaderLink>
-					<HeaderLink onClick={() => navigate('/colleges')} active={pathname === '/colleges'}>
-						대학/대학원
-					</HeaderLink>
-					<HeaderLink href="#" onClick={handleModalOpen}>
-						학사안내
-					</HeaderLink>
+					<Button onClick={onClickButton2}>대학/대학원</Button>
+					{isOpen2 && (
+						<FieldCategoryInput
+							onClose={() => {
+								setIsOpen2(false);
+							}}
+						/>
+					)}
+					<Button onClick={onClickButton1}>학사 안내</Button>
+					{isOpen1 && (
+						<CourseDetail
+							onClose={() => {
+								setIsOpen1(false);
+							}}
+						/>
+					)}
 				</HeaderLinks>
 				<HeaderActions>
 					<ExtraLinks>
@@ -109,11 +144,9 @@ function Header() {
 					</HeaderBrand>
 				</HeaderActions>
 			</HeaderContainer>
-			<Modal
-				show={showModal}
-				closed={handleModalClose}
-				item={{ content: ['학사안내 내용1', '학사안내 내용2', '학사안내 내용3'] }}
-			/>
+			{/* <Modal show={showModal} width={800} closed={handleModalClose}>
+				<CourseDetail />
+			</Modal> */}
 		</>
 	);
 }

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,206 +1,42 @@
-// import React, { useState, useEffect } from 'react';
-// import styled from 'styled-components';
-// import { CSSTransition } from 'react-transition-group';
-// import { immergeBounce, dismissBounce } from '../Animation/Animation';
+import React, { useEffect, useRef } from 'react';
+import useOutSideClick from '../../hooks/useOutsideClick';
+import ModalContainer from './ModalContainer';
+import * as L from './ModalStyles';
+import '@fortawesome/fontawesome-free/css/all.min.css';
 
-// const animationTiming = {
-// 	enter: 1000,
-// 	exit: 1000
-// };
-
-// // Styled components
-// const ModalWrapper = styled.div`
-// 	position: fixed;
-// 	z-index: 200;
-// 	border: 0.05rem solid black;
-// 	background-color: white;
-// 	padding: 10px;
-// 	text-align: center;
-// 	box-sizing: border-box;
-// 	top: 25%;
-// 	left: 25%;
-// 	width: 50%;
-
-// 	&.BounceImmerge {
-// 		animation: ${immergeBounce} 400ms ease-out forwards;
-// 	}
-
-// 	&.BounceDismiss {
-// 		animation: ${dismissBounce} 400ms ease-out forwards;
-// 	}
-// `;
-
-// const ModalContent = styled.div`
-// 	font-family: Arial;
-// 	font-size: 1rem;
-// 	text-align: start;
-// 	margin: 10px 0;
-// `;
-
-// const Modal = (props) => {
-// const [modalContent, setModalContent] = useState(null);
-// const [modalContent_sub1, setModalContent_sub1] = useState(null);
-// const [modalContent_sub2, setModalContent_sub2] = useState(null);
-// const [modalContent_sub3, setModalContent_sub3] = useState(null);
-
-// 	useEffect(() => {
-// 		if (props.show) {
-// 			setModalContent(props.item.content[0]);
-// 			setModalContent_sub1(props.item.content[0]);
-// 			setModalContent_sub2(props.item.content[0]);
-// 			setModalContent_sub3(props.item.content[0]);
-// 		}
-// 	}, [props.show, props.content]);
-
-// 	return (
-// 		<CSSTransition
-// 			in={props.show}
-// 			timeout={animationTiming}
-// 			mountOnEnter
-// 			unmountOnExit
-// 			classNames={{
-// 				appear: 'BounceImmerge',
-// 				enter: 'BounceImmerge',
-// 				exit: 'BounceDismiss'
-// 			}}
-// 		>
-// 			<ModalWrapper>
-// 				<h1>{modalContent}</h1>
-// 				<h2>
-// 					<ModalContent>내용1: {modalContent_sub1}</ModalContent>
-// 				</h2>
-// 				<h3>
-// 					<ModalContent>내용2: {modalContent_sub2}</ModalContent>
-// 				</h3>
-// 				<h4>
-// 					<ModalContent>내용3: {modalContent_sub3}</ModalContent>
-// 				</h4>
-// 				<button onClick={props.closed}>닫기</button>
-// 			</ModalWrapper>
-// 		</CSSTransition>
-// 	);
-// };
-
-// export default Modal;
-
-//------------------------------------------------------------
-import React, { useState, useEffect } from 'react';
-import { CSSTransition } from 'react-transition-group';
-import { useRecoilValue } from 'recoil';
-import { couseDetailState } from '../../recoils/atoms';
-import useClient from '../../hooks/useClient';
-import {
-	Overlay,
-	ModalWrapper,
-	Title,
-	Subtitle,
-	ModalContent,
-	ButtonContainer,
-	Button,
-	Subject,
-	SubjectContainer,
-	TableContent
-} from './ModalStyles';
-import TableComponent from '../TableComponent';
-import TableComponent2 from '../TableComponent2';
-
-const Modal = ({ show, width, closed }) => {
-	const [scrollPosition, setScrollPosition] = useState(0);
-	const couseDetail = useRecoilValue(couseDetailState);
-	const { fetchCourseDetail } = useClient();
-
-	useEffect(() => {
-		if (show) {
-			fetchCourseDetail();
-		}
-	}, [show, fetchCourseDetail]);
-
-	useEffect(() => {
-		if (show) {
-			setScrollPosition(window.scrollY);
-			document.body.style.overflow = 'hidden';
-		} else {
-			document.body.style.overflow = 'auto';
-			window.scrollTo(0, scrollPosition);
-		}
-	}, [show, scrollPosition]);
-
-	const handleOverlayClick = (e) => {
-		if (e.target === e.currentTarget) {
-			closed();
-		}
+function Modal({ onClose, children }) {
+	const modalRef = useRef(null);
+	const handleClose = () => {
+		onClose?.();
 	};
 
-	if (!couseDetail.length) return null;
+	useOutSideClick(modalRef, handleClose);
+	useEffect(() => {
+		const $body = document.querySelector('body');
+		$body.style.overflow = 'hidden';
+		return () => ($body.style.overflow = 'auto');
+	}, []);
 
-	const modalContent = couseDetail[3]; // 예시로 두 번째 데이터를 사용
-
-	const additionalInfo = modalContent.Addimfomation;
-
-	const tableData = [
-		['개설대학', additionalInfo.openingCollegeName],
-		['개설학과', additionalInfo.openingSubjectName],
-		['강의유형', additionalInfo.lectureType],
-		['학년', additionalInfo.openingSchoolYear.toString()],
-		['학기', additionalInfo.openingSemesterTerm],
-		['학점', additionalInfo.time.toString()],
-		['공학인증구분', additionalInfo.engineeringCertificationFlagCode === 0 ? 'N' : 'Y'],
-		['선수강과목', additionalInfo.preCourse],
-		['MOOC 여부', additionalInfo.moocFlag === 0 ? 'N' : 'Y'],
-		['Selc 여부', additionalInfo.selcFlag === 0 ? 'N' : 'Y'],
-		['챌린저여부', additionalInfo.dreamSemesterFlag === 0 ? 'N' : 'Y']
-	];
-
-	const tableData2 = [
-		[modalContent.competency.competencyName1, modalContent.competency.competencyRemark1],
-		[modalContent.competency.competencyName2, modalContent.competency.competencyRemark2],
-		[modalContent.competency.competencyName3, modalContent.competency.competencyRemark3]
-	];
-
-	//const courseTableData = modalContent.Addimfomation.table ? modalContent.Addimfomation.table.rows : [];
-
+	useEffect(() => {
+		const $body = document.querySelector('body');
+		const overflow = $body.style.overflow;
+		$body.style.overflow = 'hidden';
+		return () => {
+			$body.style.overflow = overflow;
+		};
+	}, []);
 	return (
-		<CSSTransition
-			in={show}
-			mountOnEnter
-			unmountOnExit
-			classNames={{
-				appear: 'BounceImmerge',
-				enter: 'BounceImmerge',
-				exit: 'BounceDismiss'
-			}}
-		>
-			<Overlay onClick={handleOverlayClick}>
-				<ModalWrapper width={width} onClick={(e) => e.stopPropagation()}>
-					<Title>Course Infomation</Title>
-					<SubjectContainer>
-						<Subject>
-							{modalContent.typicalKoreanName} ({modalContent.typicalEnglishName})
-						</Subject>
-					</SubjectContainer>
-					<Subtitle>국문설명</Subtitle>
-					<ModalContent>{modalContent.koreanDescription}</ModalContent>
-					<Subtitle>영문설명</Subtitle>
-					<ModalContent>{modalContent.englishDescription}</ModalContent>
-					{/* <Subtitle>교과 세부 정보</Subtitle>
-					<ModalContent>
-						<TableComponent data={courseTableData} />
-					</ModalContent> */}
-					<Subtitle>Additional Information</Subtitle>
-					<TableContent>
-						<TableComponent data={tableData} />
-					</TableContent>
-					<Subtitle>전공 역량</Subtitle>
-					<TableContent>
-						<TableComponent2 data={tableData2} />
-					</TableContent>
-					<ButtonContainer>
-						<Button onClick={closed}>Close</Button>
-					</ButtonContainer>
-				</ModalWrapper>
-			</Overlay>
-		</CSSTransition>
+		<ModalContainer>
+			<L.Overlay>
+				<L.ModalWrap ref={modalRef}>
+					<L.ButtonContainer>
+						<i className="fa-solid fa-xmark" onClick={handleClose} style={{ cursor: 'pointer', fontSize: '30px' }}></i>
+					</L.ButtonContainer>
+					<L.Contents>{children}</L.Contents>
+				</L.ModalWrap>
+			</L.Overlay>
+		</ModalContainer>
 	);
-};
+}
 
 export default Modal;

--- a/src/components/Modal/ModalContainer.jsx
+++ b/src/components/Modal/ModalContainer.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+function ModalContainer({ children }) {
+	return createPortal(<>{children}</>, document.getElementById('modal'));
+}
+
+export default ModalContainer;

--- a/src/components/Modal/ModalStyles.jsx
+++ b/src/components/Modal/ModalStyles.jsx
@@ -1,45 +1,53 @@
 import styled from 'styled-components';
 import { immergeBounce, dismissBounce } from '../../Animation/Animation';
 
-export const Overlay = styled.div`
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background: rgba(0, 0, 0, 0.5); /* 반투명 배경 */
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	z-index: 1000;
-`;
+// export const Overlay = styled.div`
+// 	position: fixed;
+// 	top: 0;
+// 	left: 0;
+// 	right: 0;
+// 	bottom: 0;
+// 	background: rgba(0, 0, 0, 0.5); /* 반투명 배경 */
+// 	display: flex;
+// 	align-items: center;
+// 	justify-content: center;
+// 	z-index: 1000;
+// `;
 
 export const ModalWrapper = styled.div`
-	position: fixed;
-	z-index: 200;
-	border: 0.05rem solid black;
-	background-color: white;
-	padding: 2.5rem;
-	text-align: start;
-	box-sizing: border-box;
+	// position: fixed;
+	// z-index: 200;
+	// border: 0.05rem solid black;
+	// background-color: white;
+	// padding: 2.5rem;
+	// text-align: start;
+	// box-sizing: border-box;
+	// top: 50%;
+	// left: 50%;
+	// width: ${(props) => (props.width ? `${props.width}px` : '786px')};
+	// max-width: 100%;
+	// max-height: 80vh; /* 최대 높이 조정 */
+	// overflow: auto; /* 기본 스크롤바 숨기기 */
+	// transform: translate(-50%, -50%); /* 모달을 중앙에 배치 */
+	// border-radius: 1rem; /* 모서리 둥글게 */
+	// box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* 시각적으로 모달을 돋보이게 하는 그림자 추가 */
+	// z-index: 1001; /* Overlay보다 위에 표시되도록 설정 */
+
+	// &.BounceImmerge {
+	// 	animation: ${immergeBounce} 400ms ease-out forwards;
+	// }
+
+	// &.BounceDismiss {
+	// 	animation: ${dismissBounce} 400ms ease-out forwards;
+	// }
+	width: 600px;
+	height: fit-content;
+	border-radius: 15px;
+	background-color: #fff;
+	position: absolute;
 	top: 50%;
 	left: 50%;
-	width: ${(props) => (props.width ? `${props.width}px` : '786px')};
-	max-width: 100%;
-	max-height: 80vh; /* 최대 높이 조정 */
-	overflow: auto; /* 기본 스크롤바 숨기기 */
-	transform: translate(-50%, -50%); /* 모달을 중앙에 배치 */
-	border-radius: 1rem; /* 모서리 둥글게 */
-	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* 시각적으로 모달을 돋보이게 하는 그림자 추가 */
-	z-index: 1001; /* Overlay보다 위에 표시되도록 설정 */
-
-	&.BounceImmerge {
-		animation: ${immergeBounce} 400ms ease-out forwards;
-	}
-
-	&.BounceDismiss {
-		animation: ${dismissBounce} 400ms ease-out forwards;
-	}
+	transform: translate(-50%, -50%);
 `;
 
 export const Title = styled.h1`
@@ -103,8 +111,9 @@ export const Table = styled.table`
 export const ButtonContainer = styled.div`
 	display: flex;
 	justify-content: flex-end;
-	padding-right: 1rem;
+	padding-right: 2rem;
 	margin-top: 1rem;
+	margin-bottom: 0rem;
 `;
 
 export const Button = styled.button`
@@ -123,3 +132,53 @@ export const Button = styled.button`
 		background-color: #059669; /* darker green on hover */
 	}
 `;
+//------------------
+export const Overlay = styled.div`
+	position: fixed;
+	width: 100%;
+	height: 100%;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background: rgba(0, 0, 0, 0.2);
+	z-index: 9999;
+`;
+
+export const ModalWrap = styled.div`
+	width: 600px;
+	height: fit-content;
+	border-radius: 15px;
+	background-color: #fff;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+`;
+
+export const Contents = styled.div`
+	margin: 50px 30px;
+	h1 {
+		font-size: 30px;
+		font-weight: 600;
+		margin-bottom: 60px;
+	}
+	img {
+		margin-top: 60px;
+		width: 300px;
+	}
+`;
+// const Button = styled.button`
+// 	font-size: 14px;
+// 	padding: 10px 20px;
+// 	border: none;
+// 	background-color: #ababab;
+// 	border-radius: 10px;
+// 	color: white;
+// 	font-style: italic;
+// 	font-weight: 200;
+// 	cursor: pointer;
+// 	&:hover {
+// 		background-color: #898989;
+// 	}
+// `;

--- a/src/hooks/useClient.jsx
+++ b/src/hooks/useClient.jsx
@@ -7,7 +7,7 @@ import {
 	smallFieldState,
 	competencyListInSubjectState,
 	courseByCompetencyInSubjectState,
-	couseDetailState
+	courseDetailState
 } from '../recoils/atoms';
 
 const useClient = () => {
@@ -18,7 +18,7 @@ const useClient = () => {
 	const setDetailFieldState = useSetRecoilState(detailFieldState);
 	const setCompetencyListInSubjectState = useSetRecoilState(competencyListInSubjectState);
 	const setCourseByCompetencyInSubjectState = useSetRecoilState(courseByCompetencyInSubjectState);
-	const setCourseDetailState = useSetRecoilState(couseDetailState);
+	const setCourseDetailState = useSetRecoilState(courseDetailState);
 
 	const getFilteredData = (fieldCode, responseData, offset) => {
 		const prefixReq = fieldCode.substring(0, offset);

--- a/src/hooks/useOutsideClick.jsx
+++ b/src/hooks/useOutsideClick.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+function useOutSideClick(ref, callback) {
+	useEffect(() => {
+		function handleClickOutside(event) {
+			if (ref.current && !ref.current.contains(event.target)) {
+				callback();
+			}
+		}
+
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, [ref, callback]);
+}
+
+export default useOutSideClick;

--- a/src/recoils/atoms.js
+++ b/src/recoils/atoms.js
@@ -40,7 +40,7 @@ export const courseByCompetencyInSubjectState = atom({
 	default: {}
 });
 
-export const couseDetailState = atom({
-	key: 'couseDetailState',
+export const courseDetailState = atom({
+	key: 'courseDetailState',
 	default: []
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,6 +1363,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.4.tgz#9e69f8bb4031e11df79e03db09f9dbbae1740843"
   integrity sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==
 
+"@fortawesome/fontawesome-free@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.6.0.tgz#0e984f0f2344ee513c185d87d77defac4c0c8224"
+  integrity sha512-60G28ke/sXdtS9KZCpZSHHkCbdsOGEhIUGlwq6yhY74UpTiToIh8np7A8yphhM4BWsvNFtIvLpi4co+h9Mr9Ow==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
@@ -9022,7 +9027,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9117,7 +9131,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10204,7 +10225,16 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## 구현 사항

<img width="1049" alt="image" src="https://github.com/user-attachments/assets/883d5075-3467-450f-ac79-256165f38f4c">



## 구현 설명
- Modal 분리
- Modal 상세 정보와 연결
- Modal 직군 선택과 연결
- Close Button -> X 버튼으로 조정

## 연관된 이슈
#36 

## 문제점
- 상세페이지 디자인 조정 필요
- 직군 선택 페이지에서 "검색하기" 버튼 눌렀을 시 페이지 이동 필요

## 시행착오
- Modal을 분리하니 단순히 `const courseDetail = useRecoilValue(courseDetailState);` 이렇게 데이터를 받아올 수 없었음
```
const [courseDetail, setCourseDetail] = useRecoilState(courseDetailState);
	useEffect(() => {
		fetch('/data/courseDetail.json')
			.then((response) => response.json())
			.then((data) => setCourseDetail(data))
			.catch((error) => console.error('Error fetching course details:', error));
	}, [setCourseDetail]);
```
- 이런식으로 받아오는 방법으로 수정