### PR TITLE
[Fix✏️] 모달 뒤 스크롤 문제 해결 + 타페이지 닫힘 해결

### DIFF
--- a/src/components/CourseDetail/CourseDetailStyle.jsx
+++ b/src/components/CourseDetail/CourseDetailStyle.jsx
@@ -22,7 +22,7 @@ export const Title = styled.h1`
 export const SubjectContainer = styled.div`
 	display: flex;
 	justify-content: center;
-	margin-top: 1rem;
+	margin-top: 0rem;
 `;
 
 export const Subject = styled.h1`
@@ -31,7 +31,7 @@ export const Subject = styled.h1`
 	color: black;
 	margin: 0;
 	font-size: 1.7rem;
-	padding: 0.5rem;
+	padding: 0rem;
 `;
 
 export const Subtitle = styled.h2`

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -11,20 +11,17 @@ function Modal({ onClose, children }) {
 	};
 
 	useOutSideClick(modalRef, handleClose);
-	useEffect(() => {
-		const $body = document.querySelector('body');
-		$body.style.overflow = 'hidden';
-		return () => ($body.style.overflow = 'auto');
-	}, []);
 
 	useEffect(() => {
 		const $body = document.querySelector('body');
-		const overflow = $body.style.overflow;
+		const originalOverflow = $body.style.overflow;
 		$body.style.overflow = 'hidden';
+
 		return () => {
-			$body.style.overflow = overflow;
+			$body.style.overflow = originalOverflow;
 		};
 	}, []);
+
 	return (
 		<ModalContainer>
 			<L.Overlay>

--- a/src/components/Modal/ModalStyles.jsx
+++ b/src/components/Modal/ModalStyles.jsx
@@ -40,7 +40,7 @@ export const ModalWrapper = styled.div`
 	// &.BounceDismiss {
 	// 	animation: ${dismissBounce} 400ms ease-out forwards;
 	// }
-	width: 600px;
+	width: 800px;
 	height: fit-content;
 	border-radius: 15px;
 	background-color: #fff;
@@ -113,7 +113,7 @@ export const ButtonContainer = styled.div`
 	justify-content: flex-end;
 	padding-right: 2rem;
 	margin-top: 1rem;
-	margin-bottom: 0rem;
+	margin-bottom: -2rem;
 `;
 
 export const Button = styled.button`


### PR DESCRIPTION
## 구현 사항



https://github.com/user-attachments/assets/a58b1b9e-0e28-43a2-ab10-50cee0fb1299



## 구현 설명
- Modal 닫은 후 스크롤 해결
- 로드맵 페이지 모달 닫힘 문제 해결

## 연관된 이슈
#44 

## 추가 사항
- 직군 선택 페이지에서 "검색하기" 버튼 눌렀을 시 페이지 이동 필요

## 시행착오
- useEffect 중복으로 인한 문제 -> 해결