### PR TITLE
[Feat] 상세 정보 API 연결

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -79,6 +79,8 @@ function Header() {
 		setIsOpen1(true);
 	};
 
+	const haksuId = 'BUCA65952';
+
 	return (
 		<>
 			<HeaderContainer>
@@ -99,6 +101,7 @@ function Header() {
 							onClose={() => {
 								setIsOpen1(false);
 							}}
+							HaksuId={haksuId} // 변수로 전달
 						/>
 					)}
 				</HeaderLinks>

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -5,7 +5,8 @@ import {
 	middleFieldState,
 	smallFieldState,
 	subjectsInFieldState,
-	courseByCompetencyInSubjectState
+	courseByCompetencyInSubjectState,
+	courseDetailState
 } from '../recoils/atoms';
 import useApi from './useApi';
 
@@ -17,6 +18,7 @@ const useField = () => {
 	const setDetailFieldState = useSetRecoilState(detailFieldState);
 	const setSubjectsInFieldState = useSetRecoilState(subjectsInFieldState);
 	const setCourseByCompetencyInSubjectState = useSetRecoilState(courseByCompetencyInSubjectState);
+	const setCourseDetailState = useSetRecoilState(courseDetailState);
 
 	const fetchLargeField = () => {
 		serverApi
@@ -114,6 +116,16 @@ const useField = () => {
 				console.error(error);
 			});
 	};
+	const fetchCourseDetail = (haksuId) => {
+		serverApi
+			.get(`/api/v1/courses/${haksuId}/details`)
+			.then((res) => {
+				setCourseDetailState(res.data);
+			})
+			.catch((error) => {
+				console.error('Error fetching course details:', error);
+			});
+	};
 
 	return {
 		fetchLargeField,
@@ -123,7 +135,8 @@ const useField = () => {
 		fetchSubjectsInField,
 		fetchCoursesInFieldsAndSubjects,
 		fetchCoursesInFields,
-		fetchCoursesInSubject
+		fetchCoursesInSubject,
+		fetchCourseDetail
 	};
 };
 


### PR DESCRIPTION
## 구현 사항


<img width="1202" alt="image" src="https://github.com/user-attachments/assets/228a0532-eafe-4e5c-bf5c-93074630c1af">



## 구현 설명
- 상세 정보 불러오기 (예시 넣어서 불러옴)
- 실제로는 학수번호 넣으면 상세정보 볼 수 있음

## 연관된 이슈
#46 

## 추가 사항
- 로드맵에서 연결 해야함

## 시행착오
- recoil 상태 관리 관련 수정
  - await 이용 -> 정보 기다릴 때까지 넘어가지 않도록 설정
- 로딩이 느려질 경우 is Loading 창 띄우게 설정
- 정보를 가져오지 못할 경우 -> 예외 처리 창 설정 