### PR TITLE
[Feat] 화면 비율에 맞춰 로드맵 비율 수정

### DIFF
--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -12,6 +12,7 @@ const Container = styled.div`
 `;
 
 const TitleWrapper = styled.div`
+	height: 4vh;
 	padding-top: 0.5rem;
 	padding-left: 1.5rem;
 	padding-right: 1rem;

--- a/src/components/RoadMap/RoadMapTable.jsx
+++ b/src/components/RoadMap/RoadMapTable.jsx
@@ -5,7 +5,7 @@ import CompetencyTable from './CompetencyTable';
 import Cell from './RoadMapCell';
 
 const RoadMapContainer = styled.div`
-	height: 22rem;
+	height: calc(45vh - 5rem);
 	display: flex;
 	flex-direction: row;
 	gap: 0.5rem;
@@ -23,7 +23,7 @@ const TableContainer = styled.div`
 `;
 
 const SemesterContainer = styled.div`
-	height: 2.2rem;
+	height: 2.1rem;
 	display: flex;
 	flex-direction: row;
 	gap: 0.5rem;
@@ -32,7 +32,7 @@ const SemesterContainer = styled.div`
 `;
 
 const CourseContainer = styled.div`
-	height: 19.8rem;
+	flex: 1;
 	display: flex;
 	flex-direction: row;
 	gap: 0.5rem;


### PR DESCRIPTION
## 구현 사항
<img width="1585" alt="스크린샷 2024-08-20 오후 4 16 12" src="https://github.com/user-attachments/assets/ddf6497f-a645-42f6-a054-b94c8abd829c">


## 구현 설명
- 다양한 화면 비율에서 공백이나 스크롤이 없도록 구현

