### PR TITLE
[Fix] Modal 관련 수정 사항 반영

### DIFF
--- a/src/components/CompetencyDetail/CompetencyDetail.jsx
+++ b/src/components/CompetencyDetail/CompetencyDetail.jsx
@@ -27,7 +27,7 @@ function CourseDetail({ onClose, competencyData }) {
 
 	if (loading) {
 		return (
-			<Modal onClose={onClose}>
+			<Modal width="50%" onClose={onClose}>
 				<div>Loading...</div>
 			</Modal>
 		);
@@ -36,14 +36,14 @@ function CourseDetail({ onClose, competencyData }) {
 	//오류 처리
 	if (error) {
 		return (
-			<Modal onClose={onClose}>
+			<Modal width="50%" onClose={onClose}>
 				<div>{error}</div>
 			</Modal>
 		);
 	}
 
 	return (
-		<Modal onClose={onClose}>
+		<Modal width="30%" onClose={onClose}>
 			<ScrollContainer>
 				<Title>{competencyDetail.competencyName}</Title>
 				<Subtitle>설명</Subtitle>

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -130,7 +130,7 @@ function CourseDetail({ onClose, HaksuId }) {
 				<ModalContent>{courseDetail.koreanDescription}</ModalContent>
 				<Subtitle>영문설명</Subtitle>
 				<ModalContent>{courseDetail.englishDescription}</ModalContent>
-				<Subtitle>Additional Information</Subtitle>
+				<Subtitle>기본 정보</Subtitle>
 				<TableContent>
 					<TableComponent data={tableData} />
 				</TableContent>

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -75,6 +75,7 @@ function CourseDetail({ onClose, HaksuId }) {
 	//API 연결 코드-------------------------
 
 	const tableData = [
+		['학수번호', HaksuId],
 		['개설대학', additionalInfo.openingCollegeName],
 		['개설학과', additionalInfo.openingSubjectName],
 		['강의유형', additionalInfo.lectureType],

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -4,8 +4,8 @@ import { courseDetailState } from '../../recoils/atoms';
 import {
 	Title,
 	Subtitle,
-	ModalContent,
 	Subject,
+	ModalContent,
 	SubjectContainer,
 	TableContent,
 	ScrollContainer
@@ -119,16 +119,15 @@ function CourseDetail({ onClose, HaksuId }) {
 	return (
 		<Modal onClose={onClose}>
 			<ScrollContainer>
-				<Title>Course Information</Title>
+				<Title>{courseDetail.typicalKoreanName}</Title>
 
 				<SubjectContainer>
-					<Subject>
+					{/* <Subject>
 						{courseDetail.typicalKoreanName} ({courseDetail.typicalEnglishName})
-					</Subject>
+					</Subject> */}
 				</SubjectContainer>
-				<Subtitle>국문설명</Subtitle>
 				<ModalContent>{courseDetail.koreanDescription}</ModalContent>
-				<Subtitle>영문설명</Subtitle>
+				<Subject>{courseDetail.typicalEnglishName}</Subject>
 				<ModalContent>{courseDetail.englishDescription}</ModalContent>
 				<Subtitle>기본 정보</Subtitle>
 				<TableContent>

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -16,28 +16,6 @@ import Modal from '../Modal/Modal';
 import useField from '../../hooks/useField';
 
 function CourseDetail({ onClose, HaksuId }) {
-	//MockDATA 이용 -------------
-	// const [courseDetail, setCourseDetail] = useRecoilState(courseDetailState);
-	// useEffect(() => {
-	// 	fetch('/data/courseDetail.json')
-	// 		.then((response) => response.json())
-	// 		.then((data) => setCourseDetail(data))
-	// 		.catch((error) => console.error('Error fetching course details:', error));
-	// }, [setCourseDetail]);
-
-	// const modalContent = courseDetail[1]; // 예시로 네 번째 데이터를 사용
-
-	// console.log('Course Detail:', courseDetail); // 데이터 확인
-	// console.log('modalContent :', modalContent);
-	// if (!courseDetail.length)
-	// 	return (
-	// 		<Modal onClose={onClose}>
-	// 			<div>Loading...</div>
-	// 		</Modal>
-	// 	); // 데이터가 없을 때 로딩 표시
-
-	//---------------------------
-
 	const [courseDetail, setCourseDetail] = useRecoilState(courseDetailState);
 	const { fetchCourseDetail } = useField();
 	const [loading, setLoading] = useState(true);

--- a/src/components/CourseDetail/CourseDetailStyle.jsx
+++ b/src/components/CourseDetail/CourseDetailStyle.jsx
@@ -6,10 +6,12 @@ export const ScrollContainer = styled.div`
 	border-radius: 8px;
 	max-height: 80vh; /* 내용물의 최대 높이 설정 */
 	overflow-y: auto; /* 세로 스크롤바 표시 */
+	width: 100%;
 `;
 
 export const Title = styled.h1`
 	background-color: #036b3f;
+	text-align: center;
 	padding: 1rem;
 	border-radius: 8px;
 	color: white;
@@ -23,13 +25,13 @@ export const SubjectContainer = styled.div`
 	margin-top: 0rem;
 `;
 
-export const Subject = styled.h1`
-	justify-content: center;
-	border-radius: 8px;
-	color: black;
-	margin: 0;
-	font-size: 1.7rem;
-	padding: 0rem;
+export const Subject = styled.div`
+	color: #036b3f; /* main color */
+	text-align: center;
+	font-size: 1.5rem;
+	margin: 0.5rem 20px;
+	padding-top: 2rem;
+	padding-bottom: 1rem;
 `;
 
 export const Subtitle = styled.h2`

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -4,7 +4,7 @@ import ModalContainer from './ModalContainer';
 import * as L from './ModalStyles';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
-function Modal({ onClose, children }) {
+function Modal({ onClose, children, width }) {
 	const modalRef = useRef(null);
 	const handleClose = () => {
 		onClose?.();
@@ -25,7 +25,7 @@ function Modal({ onClose, children }) {
 	return (
 		<ModalContainer>
 			<L.Overlay>
-				<L.ModalWrap ref={modalRef}>
+				<L.ModalWrap ref={modalRef} width={width}>
 					<L.ButtonContainer>
 						<i className="fa-solid fa-xmark" onClick={handleClose} style={{ cursor: 'pointer', fontSize: '30px' }}></i>
 					</L.ButtonContainer>

--- a/src/components/Modal/ModalStyles.jsx
+++ b/src/components/Modal/ModalStyles.jsx
@@ -27,7 +27,7 @@ export const Overlay = styled.div`
 `;
 
 export const ModalWrap = styled.div`
-	width: 70%;
+	width: ${(props) => props.width || '70%'};
 	height: fit-content;
 	border-radius: 15px;
 	background-color: #fff;

--- a/src/components/Modal/TableComponent.jsx
+++ b/src/components/Modal/TableComponent.jsx
@@ -22,6 +22,7 @@ const Th = styled.th`
 	color: white;
 	border: 1px solid black; /* 테두리 추가 */
 	font-size: 14px; /* 셀의 폰트 크기 설정 */
+	width: 50%;
 `;
 
 const Td = styled.td`
@@ -29,6 +30,7 @@ const Td = styled.td`
 	text-align: center;
 	border: 1px solid black; /* 테두리 추가 */
 	font-size: 14px; /* 셀의 폰트 크기 설정 */
+	width: 50%;
 `;
 
 const TableComponent = ({ data }) => {

--- a/src/components/Modal/TableComponent.jsx
+++ b/src/components/Modal/TableComponent.jsx
@@ -37,8 +37,8 @@ const TableComponent = ({ data }) => {
 			<StyledTable>
 				<thead>
 					<tr>
-						<Th>분류</Th>
-						<Th>특징</Th>
+						<Th>구분</Th>
+						<Th>내용</Th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/components/Modal/TableComponent2.jsx
+++ b/src/components/Modal/TableComponent2.jsx
@@ -40,8 +40,8 @@ const TableComponent2 = ({ data }) => {
 				<thead>
 					<tr>
 						<Th>분류</Th>
-						<Th>특징</Th>
-						<Th>설명</Th>
+						<Th>전공역량명</Th>
+						<Th>전공역량 정의</Th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/components/Modal/TableComponent2.jsx
+++ b/src/components/Modal/TableComponent2.jsx
@@ -20,15 +20,20 @@ const Th = styled.th`
 	background-color: #036b3f;
 	text-align: center;
 	color: white;
-	font-size: 12px; /* 헤더의 폰트 크기 설정 */
+	font-size: 14px; /* 헤더의 폰트 크기 설정 */
 	border: 1px solid black; /* 테두리 추가 */
 `;
 
 const Td = styled.td`
 	padding: 8px;
 	text-align: center;
-	font-size: 12px; /* 셀의 폰트 크기 설정 */
+	font-size: 13px; /* 셀의 폰트 크기 설정 */
 	border: 1px solid black; /* 테두리 추가 */
+
+	/* competencyRemark 열에만 적용할 스타일 */
+	&.remark {
+		text-align: left;
+	}
 `;
 
 const TableComponent2 = ({ data }) => {
@@ -49,7 +54,9 @@ const TableComponent2 = ({ data }) => {
 						<tr key={i}>
 							<Td>{headers[i]}</Td>
 							{row.map((cell, j) => (
-								<Td key={j}>{cell}</Td>
+								<Td key={j} className={j === 1 ? 'remark' : ''}>
+									{cell}
+								</Td>
 							))}
 						</tr>
 					))}


### PR DESCRIPTION
## 구현 사항
<p align="center">
<img width=70% alt="스크린샷 2024-08-28 오전 12 58 26" src="https://github.com/user-attachments/assets/ca6f5317-a0c5-42de-a8fd-01876a380818">

</p>

- 모달 크기 조정 가능하도록 수정 (width = 50% 이런식으로 사용(%))
- 전공역량 상세 모달에 30%로 적용시킴

<p align="center">
<img width=70%  alt="스크린샷 2024-08-28 오전 1 11 39" src="https://github.com/user-attachments/assets/53ebbc1c-7b2c-4294-bd47-29abf2d2d30c">
</p>

- 설명 길이에 따라 width 안 바뀌도록 조정
- 배치 변경
  - 국문 과목명 위로 올리기, 국어 설명 그냥 넣기 (제목 없이),영어 과목명 (초록색) ,아래에 영어 설명
- 멘트 수정
  - 분류 특징 → 구분 내용
  - Additional info → 기본 정보
  -  분류 , 전공역량명, 전공역량 정의

<p align="center">
<img width=70%  alt="스크린샷 2024-08-28 오전 1 17 50" src="https://github.com/user-attachments/assets/8b592730-7265-4e97-95c9-019754dab174">
</p>

- 학수코드 추가
- 기본정보 표 중간 선 고정 (50%)
<p align="center">
<img width=70% alt="image" src="https://github.com/user-attachments/assets/65b3ba5a-3829-4fb1-aeaf-a83503551723">
</p>


- 전공역량 정의 좌측 정렬
- 폰트 크기 조정

## 🚀 로직 설명 및 코드 설명

```
<Modal width="30%" onClose={onClose}>
			<ScrollContainer>
				<Title>{competencyDetail.competencyName}</Title>
				<Subtitle>설명</Subtitle>
				<ModalContent>{competencyDetail.competencyDescription}</ModalContent>
			</ScrollContainer>
		</Modal>
```
- 이런식으로 width 설정해서 사용할 수 있음 -> 설정 안할 시 기본값 70%

## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 과목 상세 정보에서 -> 영어 과목명 중앙 정렬이 나은지? 좌측 정렬이 나은지?
  - 위에 한글 과목명이 중앙 정렬이라 이에 맞게 중앙정렬로 해놓긴 했음
- 전공역량 상세 정보 모달 가로 길이 조절하셔도 됩니다~!
