### PR TITLE
[Fix] Cell border 색상 소프트하게 변경

### DIFF
--- a/src/components/GlobalStyle.jsx
+++ b/src/components/GlobalStyle.jsx
@@ -7,9 +7,9 @@ const GlobalStyle = createGlobalStyle`
   @font-face {
     font-family: 'Pretendard-regular';
     src: url(${Pretendard_regular}) format('opentype');
-    font-weight: normal;
+    font-weight: 100;
     font-style: normal;
-    font-display: swap;
+    font-display: block;
   }
 
   @font-face {
@@ -17,7 +17,7 @@ const GlobalStyle = createGlobalStyle`
     src: url(${Pretendard_semiBold}) format('opentype');
     font-weight: normal;
     font-style: normal;
-    font-display: swap;
+    font-display: block;
   }
 
   @font-face {
@@ -25,11 +25,11 @@ const GlobalStyle = createGlobalStyle`
     src: url(${Pretendard_bold}) format('opentype');
     font-weight: normal;
     font-style: normal;
-    font-display: swap;
+    font-display: block;
   }
 
   body {
-    font-family: 'Pretendard-semiBold';
+    font-family: 'Pretendard-bold';
     margin: 0;
     padding: 0;
   }

--- a/src/components/RoadMap/CompetencyCell.jsx
+++ b/src/components/RoadMap/CompetencyCell.jsx
@@ -7,7 +7,7 @@ const StyledCell = styled.div`
 	min-height: 2rem;
 	font-size: small;
 	box-sizing: border-box;
-	border: 0.05rem solid black;
+	border: 1px solid #a4a4a4;
 	border-radius: 0.2rem;
 	background-color: white;
 	cursor: pointer;

--- a/src/components/RoadMap/CompetencyTable.jsx
+++ b/src/components/RoadMap/CompetencyTable.jsx
@@ -7,7 +7,7 @@ const Container = styled.div`
 	width: 15%;
 	height: auto;
 	box-sizing: border-box;
-	border: 0.05rem solid black;
+	border: 1px solid gray;
 	border-radius: 0.2rem;
 	background-color: #f4f4f4;
 	display: flex;

--- a/src/components/RoadMap/CourseCreditTable.jsx
+++ b/src/components/RoadMap/CourseCreditTable.jsx
@@ -9,7 +9,7 @@ const CourseCreditContainer = styled.div`
 	align-items: center;
 	gap: 0.5rem;
 	box-sizing: border-box;
-	border: 0.05rem solid black;
+	border: 0.05rem solid gray;
 	border-radius: 0.2rem;
 	background-color: #f4f4f4;
 `;

--- a/src/components/RoadMap/RoadMapCell.jsx
+++ b/src/components/RoadMap/RoadMapCell.jsx
@@ -8,7 +8,7 @@ const StyledCell = styled.div`
 	min-height: 2rem;
 	display: flex;
 	font-size: small;
-	border: 0.05rem solid black;
+	border: 1px solid gray;
 	border-radius: 0.2rem;
 	background-color: white;
 	cursor: pointer;

--- a/src/components/RoadMap/RoadMapCell2.jsx
+++ b/src/components/RoadMap/RoadMapCell2.jsx
@@ -34,10 +34,11 @@ const DropdownItem = styled.div`
 `;
 
 const StyledCell = styled.div`
+	font-family: 'Pretendard-regular';
+	font-size: small;
 	min-height: 2rem;
 	display: flex;
-	font-size: small;
-	border: 0.05rem solid black;
+	border: 1px solid #a4a4a4;
 	border-radius: 0.2rem;
 	background-color: white;
 	cursor: pointer;
@@ -67,7 +68,6 @@ const StyledCell = styled.div`
 `;
 
 const CourseTitle = styled.div`
-	font-family: 'Pretendard-regular';
 	padding: 0 0.7rem;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/src/components/RoadMap/RoadMapTable.jsx
+++ b/src/components/RoadMap/RoadMapTable.jsx
@@ -21,6 +21,15 @@ const SemesterContainer = styled.div`
 	overflow-x: hidden;
 `;
 
+const SemesterColumn = styled.div`
+	min-width: 0;
+	height: fit-content;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+`;
+
 const CourseContainer = styled.div`
 	flex: 1;
 	display: flex;
@@ -32,10 +41,12 @@ const CourseContainer = styled.div`
 
 const CourseColumn = styled.div`
 	min-width: 0;
+	height: fit-content;
 	flex: 1;
 	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
+	padding-bottom: 0.5rem;
 `;
 
 const animationTiming = {
@@ -72,11 +83,11 @@ const RoadMapTable = ({ roadMapTableData, onCellClick, unclickableCells, highlig
 		<TableContainer>
 			<SemesterContainer>
 				{defaultTable.map((row, rowIndex) => (
-					<CourseColumn key={rowIndex}>
+					<SemesterColumn key={rowIndex}>
 						{row.map((cellData) => (
 							<Cell key={cellData.haksuId} cellData={cellData} rowIndex={rowIndex} unclickable={true} />
 						))}
-					</CourseColumn>
+					</SemesterColumn>
 				))}
 			</SemesterContainer>
 			<CourseContainer>


### PR DESCRIPTION
## 구현 사항
![image](https://github.com/user-attachments/assets/461106ca-8b72-4104-b2f1-08ebcb9bc2d2)

## 🚀 로직 설명 및 코드 설명

- Cell 테두리 색상을 소프트하게 변경
- 교과목 테이블 스크롤을 가장 밑으로 내렸을 시 Cell 밑부분이 보이지 않는 이슈 수정

## 연관된 이슈

- 세부 옵션 선택 박스가 RoadMapColumn 안에만 존재해서 발생하는 사소한 스크롤 문제

## 🤔고민 사항

- 글씨체가 너무 딱딱한 느낌이 드는 것 같기도 함
