### PR TITLE
[Feat] 상세정보 모달 수정 + 수강 경쟁률 추가

### DIFF
--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import * as L from './CourseDetailStyle';
+
+const Container = styled.div`
+	background-color: transparent;
+	padding: 0rem;
+	width: 100%;
+`;
+
+const TableContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	margin-top: 20px;
+`;
+
+const Table = styled.table`
+	width: 80%;
+	border-collapse: collapse;
+	margin-bottom: 20px;
+	table-layout: fixed;
+`;
+
+const Th = styled.th`
+	padding: 10px;
+	background-color: #f0f0f0;
+	border: 1px solid #ddd;
+	text-align: center;
+	width: 33.33%; /* 각 열의 너비를 전체의 1/3로 설정 */
+`;
+
+const Td = styled.td`
+	padding: 10px;
+	border: 1px solid #ddd;
+	text-align: center;
+	width: 33.33%; /* 각 열의 너비를 전체의 1/3로 설정 */
+`;
+
+const ButtonContainer = styled.div`
+	display: flex;
+	gap: 10px;
+	margin: 0 auto 20px;
+	width: 80%;
+	justify-content: center;
+`;
+const GradeButton = styled.button`
+	padding: 8px 16px;
+	background-color: ${({ active }) => (active ? '#036b3f' : '#ddd')};
+	color: ${({ active }) => (active ? 'white' : 'black')};
+	border: none;
+	border-radius: 5px;
+	cursor: pointer;
+	&:hover {
+		background-color: #036b3f;
+		color: white;
+	}
+`;
+//DummyData 이용
+const data = {
+	total: { students: 100, capacity: 120, competitionRate: '1.2' },
+	grades: {
+		1: { students: 30, capacity: 35, competitionRate: '0.86' },
+		2: { students: 25, capacity: 30, competitionRate: '0.83' },
+		3: { students: 20, capacity: 25, competitionRate: '0.8' },
+		4: { students: 25, capacity: 30, competitionRate: '0.83' }
+	}
+};
+
+const CompetitionTable = () => {
+	const [selectedGrade, setSelectedGrade] = useState(1);
+
+	return (
+		<Container>
+			<L.Subtitle>수강 신청 경쟁률</L.Subtitle>
+
+			{/* 전체 학년 정보 */}
+			<TableContainer>
+				<Table>
+					<thead>
+						<tr>
+							<Th>총 수강 인원</Th>
+							<Th>수강 정원</Th>
+							<Th>경쟁률</Th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<Td>{data.total.students}</Td>
+							<Td>{data.total.capacity}</Td>
+							<Td>{data.total.competitionRate}</Td>
+						</tr>
+					</tbody>
+				</Table>
+			</TableContainer>
+
+			{/* 학년 선택 버튼 */}
+			<ButtonContainer>
+				{[1, 2, 3, 4].map((grade) => (
+					<GradeButton key={grade} active={selectedGrade === grade} onClick={() => setSelectedGrade(grade)}>
+						{grade}학년
+					</GradeButton>
+				))}
+			</ButtonContainer>
+
+			{/* 선택된 학년 정보 */}
+			<TableContainer>
+				<Table>
+					<thead>
+						<tr>
+							<Th>수강 인원</Th>
+							<Th>수강 정원</Th>
+							<Th>경쟁률</Th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<Td>{data.grades[selectedGrade].students}</Td>
+							<Td>{data.grades[selectedGrade].capacity}</Td>
+							<Td>{data.grades[selectedGrade].competitionRate}</Td>
+						</tr>
+					</tbody>
+				</Table>
+			</TableContainer>
+		</Container>
+	);
+};
+
+export default CompetitionTable;

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -16,6 +16,15 @@ const TableContainer = styled.div`
 	justify-content: center;
 	margin-top: 20px;
 `;
+const TextContainer = styled.div`
+	font-family: 'Pretendard-regular';
+	margin: 0px 20px;
+	display: flex;
+	justify-content: flex-start;
+	margin-top: 10px;
+	color: #808080;
+	font-size: 0.8rem;
+`;
 
 const Table = styled.table`
 	width: 80%;
@@ -85,11 +94,11 @@ const CompetitionTable = ({ haksuId }) => {
 		const loadCompetitionRate = async () => {
 			if (haksuId) {
 				try {
-					const data = await fetchCompetitionRate(haksuId); // 비동기 함수로 데이터를 가져옴
-					setCompetitionRateState(data); // 가져온 데이터를 상태에 저장
+					const data = await fetchCompetitionRate(haksuId);
+					setCompetitionRateState(data);
 				} catch (error) {
 					console.error('Error fetching competition rate:', error);
-					setCompetitionRateState(null); // 에러가 발생한 경우 상태를 초기화
+					setCompetitionRateState(null);
 				}
 				console.log(competitionData);
 			}
@@ -129,7 +138,7 @@ const CompetitionTable = ({ haksuId }) => {
 	return (
 		<Container>
 			<L.Subtitle>수강 신청 경쟁률</L.Subtitle>
-
+			<TextContainer>* 2023,2024학년도 데이터를 기준으로 산출하였습니다.</TextContainer>
 			{/* 전체 학년 정보 */}
 			<TableContainer>
 				<Table>

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -22,6 +22,7 @@ const Table = styled.table`
 `;
 
 const Th = styled.th`
+	font-family: 'Pretendard-regular';
 	padding: 10px;
 	background-color: #f0f0f0;
 	border: 1px solid #ddd;
@@ -30,6 +31,7 @@ const Th = styled.th`
 `;
 
 const Td = styled.td`
+	font-family: 'Pretendard-regular';
 	padding: 10px;
 	border: 1px solid #ddd;
 	text-align: center;
@@ -37,6 +39,7 @@ const Td = styled.td`
 `;
 
 const ButtonContainer = styled.div`
+	font-family: 'Pretendard-regular';
 	display: flex;
 	gap: 10px;
 	margin: 0 auto 20px;

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -1,6 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import * as L from './CourseDetailStyle';
+import { competitionRateState } from '../../recoils/atoms';
+import useField from '../../hooks/useField';
 
 const Container = styled.div`
 	background-color: transparent;
@@ -23,6 +26,7 @@ const Table = styled.table`
 
 const Th = styled.th`
 	font-family: 'Pretendard-regular';
+	font-size: 14px;
 	padding: 10px;
 	background-color: #f0f0f0;
 	border: 1px solid #ddd;
@@ -32,6 +36,7 @@ const Th = styled.th`
 
 const Td = styled.td`
 	font-family: 'Pretendard-regular';
+	font-size: 13px;
 	padding: 10px;
 	border: 1px solid #ddd;
 	text-align: center;
@@ -59,18 +64,67 @@ const GradeButton = styled.button`
 	}
 `;
 //DummyData 이용
-const data = {
-	total: { students: 100, capacity: 120, competitionRate: '1.2' },
-	grades: {
-		1: { students: 30, capacity: 35, competitionRate: '0.86' },
-		2: { students: 25, capacity: 30, competitionRate: '0.83' },
-		3: { students: 20, capacity: 25, competitionRate: '0.8' },
-		4: { students: 25, capacity: 30, competitionRate: '0.83' }
-	}
-};
+// const data = {
+// 	total: { students: 100, capacity: 120, competitionRate: '0.83' },
+// 	grades: {
+// 		1: { students: 30, capacity: 35, competitionRate: '0.86' },
+// 		2: { students: 25, capacity: 30, competitionRate: '0.83' },
+// 		3: { students: 20, capacity: 25, competitionRate: '0.8' },
+// 		4: { students: 25, capacity: 30, competitionRate: '0.83' }
+// 	}
+// };
 
-const CompetitionTable = () => {
+const CompetitionTable = ({ haksuId }) => {
+	const { fetchCompetitionRate } = useField();
 	const [selectedGrade, setSelectedGrade] = useState(1);
+	const setCompetitionRateState = useSetRecoilState(competitionRateState);
+	const competitionData = useRecoilValue(competitionRateState);
+
+	//API 이용
+	useEffect(() => {
+		const loadCompetitionRate = async () => {
+			if (haksuId) {
+				try {
+					const data = await fetchCompetitionRate(haksuId); // 비동기 함수로 데이터를 가져옴
+					setCompetitionRateState(data); // 가져온 데이터를 상태에 저장
+				} catch (error) {
+					console.error('Error fetching competition rate:', error);
+					setCompetitionRateState(null); // 에러가 발생한 경우 상태를 초기화
+				}
+				console.log(competitionData);
+			}
+		};
+
+		loadCompetitionRate();
+	}, [haksuId]);
+
+	const gradeMapping = {
+		total: {
+			students: competitionData?.competitionRates?.totalNumber || '-',
+			capacity: competitionData?.competitionRates?.totalCourseBasketNumber || '-',
+			rate: competitionData?.competitionRates?.totalCompetitionRate || '-'
+		},
+		1: {
+			students: competitionData?.competitionRates?.freshmanTotalNumber || '-',
+			capacity: competitionData?.competitionRates?.freshmanCourseBasketNumber || '-',
+			rate: competitionData?.competitionRates?.freshmanCompetitionRate || '-'
+		},
+		2: {
+			students: competitionData?.competitionRates?.sophomoreTotalNumber || '-',
+			capacity: competitionData?.competitionRates?.sophomoreCourseBasketNumber || '-',
+			rate: competitionData?.competitionRates?.sophomoreCompetitionRate || '-'
+		},
+		3: {
+			students: competitionData?.competitionRates?.juniorTotalNumber || '-',
+			capacity: competitionData?.competitionRates?.juniorCourseBasketNumber || '-',
+			rate: competitionData?.competitionRates?.juniorCompetitionRate || '-'
+		},
+		4: {
+			students: competitionData?.competitionRates?.seniorTotalNumber || '-',
+			capacity: competitionData?.competitionRates?.seniorCourseBasketNumber || '-',
+			rate: competitionData?.competitionRates?.seniorCompetitionRate || '-'
+		}
+	};
 
 	return (
 		<Container>
@@ -81,16 +135,16 @@ const CompetitionTable = () => {
 				<Table>
 					<thead>
 						<tr>
-							<Th>총 수강 인원</Th>
+							<Th>실 수강인원</Th>
 							<Th>수강 정원</Th>
 							<Th>경쟁률</Th>
 						</tr>
 					</thead>
 					<tbody>
 						<tr>
-							<Td>{data.total.students}</Td>
-							<Td>{data.total.capacity}</Td>
-							<Td>{data.total.competitionRate}</Td>
+							<Td>{gradeMapping['total'].capacity}</Td>
+							<Td>{gradeMapping['total'].students}</Td>
+							<Td>{gradeMapping['total'].rate}</Td>
 						</tr>
 					</tbody>
 				</Table>
@@ -110,16 +164,16 @@ const CompetitionTable = () => {
 				<Table>
 					<thead>
 						<tr>
-							<Th>수강 인원</Th>
+							<Th>실 수강인원</Th>
 							<Th>수강 정원</Th>
 							<Th>경쟁률</Th>
 						</tr>
 					</thead>
 					<tbody>
 						<tr>
-							<Td>{data.grades[selectedGrade].students}</Td>
-							<Td>{data.grades[selectedGrade].capacity}</Td>
-							<Td>{data.grades[selectedGrade].competitionRate}</Td>
+							<Td>{gradeMapping[selectedGrade].capacity}</Td>
+							<Td>{gradeMapping[selectedGrade].students}</Td>
+							<Td>{gradeMapping[selectedGrade].rate}</Td>
 						</tr>
 					</tbody>
 				</Table>

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -136,6 +136,7 @@ const CompetitionTable = ({ haksuId }) => {
 				<Table>
 					<thead>
 						<tr>
+							<Th>실 수강인원</Th>
 							<Th>수강 바구니</Th>
 							<Th>수강 정원</Th>
 							<Th>경쟁률</Th>
@@ -143,6 +144,7 @@ const CompetitionTable = ({ haksuId }) => {
 					</thead>
 					<tbody>
 						<tr>
+							<Td>{competitionData?.totalApplicationNumber || '-'}</Td>
 							<Td>{gradeMapping['total'].capacity}</Td>
 							<Td>{gradeMapping['total'].students}</Td>
 							<Td>{gradeMapping['total'].rate}</Td>

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -139,7 +139,7 @@ const CompetitionTable = ({ haksuId }) => {
 							<Th>실 수강인원</Th>
 							<Th>수강 바구니</Th>
 							<Th>수강 정원</Th>
-							<Th>경쟁률</Th>
+							<Th>전체 경쟁률</Th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -37,8 +37,10 @@ const Th = styled.th`
 	font-family: 'Pretendard-regular';
 	font-size: 14px;
 	padding: 10px;
-	background-color: #f0f0f0;
-	border: 1px solid #ddd;
+	// background-color: #f0f0f0;
+	// border: 1px solid #ddd;
+	background-color: #036b3f;
+	color: #ffffff;
 	text-align: center;
 	width: 33.33%; /* 각 열의 너비를 전체의 1/3로 설정 */
 `;
@@ -144,7 +146,7 @@ const CompetitionTable = ({ haksuId }) => {
 				<Table>
 					<thead>
 						<tr>
-							<Th>실 수강인원</Th>
+							<Th>수강 바구니</Th>
 							<Th>수강 정원</Th>
 							<Th>경쟁률</Th>
 						</tr>
@@ -173,7 +175,7 @@ const CompetitionTable = ({ haksuId }) => {
 				<Table>
 					<thead>
 						<tr>
-							<Th>실 수강인원</Th>
+							<Th>수강 바구니</Th>
 							<Th>수강 정원</Th>
 							<Th>경쟁률</Th>
 						</tr>

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -42,7 +42,7 @@ const Th = styled.th`
 	background-color: #036b3f;
 	color: #ffffff;
 	text-align: center;
-	width: 33.33%; /* 각 열의 너비를 전체의 1/3로 설정 */
+	width: 33.33%;
 `;
 
 const Td = styled.td`
@@ -51,7 +51,7 @@ const Td = styled.td`
 	padding: 10px;
 	border: 1px solid #ddd;
 	text-align: center;
-	width: 33.33%; /* 각 열의 너비를 전체의 1/3로 설정 */
+	width: 33.33%;
 `;
 
 const ButtonContainer = styled.div`
@@ -74,16 +74,6 @@ const GradeButton = styled.button`
 		color: white;
 	}
 `;
-//DummyData 이용
-// const data = {
-// 	total: { students: 100, capacity: 120, competitionRate: '0.83' },
-// 	grades: {
-// 		1: { students: 30, capacity: 35, competitionRate: '0.86' },
-// 		2: { students: 25, capacity: 30, competitionRate: '0.83' },
-// 		3: { students: 20, capacity: 25, competitionRate: '0.8' },
-// 		4: { students: 25, capacity: 30, competitionRate: '0.83' }
-// 	}
-// };
 
 const CompetitionTable = ({ haksuId }) => {
 	const { fetchCompetitionRate } = useField();

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -14,6 +14,7 @@ import TableComponent from '../Modal/TableComponent';
 import TableComponent2 from '../Modal/TableComponent2';
 import Modal from '../Modal/Modal';
 import useField from '../../hooks/useField';
+import MenuList from './MenuList';
 
 function CourseDetail({ onClose, HaksuId }) {
 	const [courseDetail, setCourseDetail] = useRecoilState(courseDetailState);
@@ -99,6 +100,7 @@ function CourseDetail({ onClose, HaksuId }) {
 		<Modal onClose={onClose}>
 			<ScrollContainer>
 				<Title>{courseDetail.typicalKoreanName}</Title>
+				<MenuList></MenuList>
 
 				<SubjectContainer>
 					{/* <Subject>

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -4,7 +4,7 @@ import { courseDetailState } from '../../recoils/atoms';
 import {
 	Title,
 	Subtitle,
-	Subject,
+	// Subject,
 	ModalContent,
 	SubjectContainer,
 	TableContent,
@@ -75,24 +75,24 @@ function CourseDetail({ onClose, HaksuId }) {
 	//API 연결 코드-------------------------
 
 	const tableData = [
-		['학수번호', HaksuId],
-		['개설대학', additionalInfo.openingCollegeName],
-		['개설학과', additionalInfo.openingSubjectName],
-		['강의유형', additionalInfo.lectureType],
-		['학년', additionalInfo.openingSchoolYear.toString()],
-		['학기', additionalInfo.openingSemesterTerm],
-		['학점', additionalInfo.time.toString()],
+		['학수번호', HaksuId || '-'],
+		['개설대학', additionalInfo.openingCollegeName || '-'],
+		['개설학과', additionalInfo.openingSubjectName || '-'],
+		['강의유형', additionalInfo.lectureType || '-'],
+		['학년', additionalInfo.openingSchoolYear?.toString() || '-'],
+		['학기', additionalInfo.openingSemesterTerm || '-'],
+		['학점', additionalInfo.time?.toString() || '-'],
 		['공학인증구분', additionalInfo.engineeringCertificationFlagCode === 0 ? 'N' : 'Y'],
-		['선수강과목', additionalInfo.preCourse],
-		['MOOC 여부', additionalInfo.moocFlag === 0 ? 'N' : 'Y'],
-		['Selc 여부', additionalInfo.selcFlag === 0 ? 'N' : 'Y'],
-		['챌린저여부', additionalInfo.dreamSemesterFlag === 0 ? 'N' : 'Y']
+		['선수강과목', additionalInfo.preCourse || '-']
+		// ['MOOC 여부', additionalInfo.moocFlag === 0 ? 'N' : 'Y'],
+		// ['Selc 여부', additionalInfo.selcFlag === 0 ? 'N' : 'Y'],
+		// ['챌린저여부', additionalInfo.dreamSemesterFlag === 0 ? 'N' : 'Y']
 	];
 
 	const tableData2 = [
-		[competency.competencyName1, competency.competencyRemark1],
-		[competency.competencyName2, competency.competencyRemark2],
-		[competency.competencyName3, competency.competencyRemark3]
+		[competency.competencyName1 || '-', competency.competencyRemark1 || '-'],
+		[competency.competencyName2 || '-', competency.competencyRemark2 || '-'],
+		[competency.competencyName3 || '-', competency.competencyRemark3 || '-']
 	];
 
 	return (
@@ -105,9 +105,10 @@ function CourseDetail({ onClose, HaksuId }) {
 						{courseDetail.typicalKoreanName} ({courseDetail.typicalEnglishName})
 					</Subject> */}
 				</SubjectContainer>
+				<Subtitle>과목 설명</Subtitle>
 				<ModalContent>{courseDetail.koreanDescription}</ModalContent>
-				<Subject>{courseDetail.typicalEnglishName}</Subject>
-				<ModalContent>{courseDetail.englishDescription}</ModalContent>
+				{/* <Subject>{courseDetail.typicalEnglishName}</Subject>
+				<ModalContent>{courseDetail.englishDescription}</ModalContent> */}
 				<Subtitle>기본 정보</Subtitle>
 				<TableContent>
 					<TableComponent data={tableData} />

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -18,6 +18,7 @@ import MenuList from './MenuList';
 import CompetitionTable from './CompetitionTable';
 
 function CourseDetail({ onClose, HaksuId }) {
+	console.log(HaksuId);
 	const [courseDetail, setCourseDetail] = useRecoilState(courseDetailState);
 	const { fetchCourseDetail } = useField();
 	const [loading, setLoading] = useState(true);
@@ -91,6 +92,8 @@ function CourseDetail({ onClose, HaksuId }) {
 		// ['챌린저여부', additionalInfo.dreamSemesterFlag === 0 ? 'N' : 'Y']
 	];
 
+	console.log(HaksuId);
+
 	const tableData2 = [
 		[competency.competencyName1 || '-', competency.competencyRemark1 || '-'],
 		[competency.competencyName2 || '-', competency.competencyRemark2 || '-'],
@@ -102,7 +105,6 @@ function CourseDetail({ onClose, HaksuId }) {
 			<ScrollContainer>
 				<Title>{courseDetail.typicalKoreanName}</Title>
 				<MenuList></MenuList>
-
 				{/* <SubjectContainer>
 					<Subject>
 						{courseDetail.typicalKoreanName} ({courseDetail.typicalEnglishName})
@@ -120,7 +122,7 @@ function CourseDetail({ onClose, HaksuId }) {
 				<TableContent>
 					<TableComponent2 data={tableData2} />
 				</TableContent>
-				<CompetitionTable></CompetitionTable>
+				<CompetitionTable haksuId={HaksuId} />
 			</ScrollContainer>
 		</Modal>
 	);

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -1,15 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { courseDetailState } from '../../recoils/atoms';
-import {
-	Title,
-	Subtitle,
-	// Subject,
-	ModalContent,
-	//SubjectContainer,
-	TableContent,
-	ScrollContainer
-} from './CourseDetailStyle';
+import { Title, Subtitle, ModalContent, TableContent, ScrollContainer } from './CourseDetailStyle';
 import TableComponent from '../Modal/TableComponent';
 import TableComponent2 from '../Modal/TableComponent2';
 import Modal from '../Modal/Modal';
@@ -87,9 +79,6 @@ function CourseDetail({ onClose, HaksuId }) {
 		['학점', additionalInfo.time?.toString() || '-'],
 		['공학인증구분', additionalInfo.engineeringCertificationFlagCode === 0 ? 'N' : 'Y'],
 		['선수강과목', additionalInfo.preCourse || '-']
-		// ['MOOC 여부', additionalInfo.moocFlag === 0 ? 'N' : 'Y'],
-		// ['Selc 여부', additionalInfo.selcFlag === 0 ? 'N' : 'Y'],
-		// ['챌린저여부', additionalInfo.dreamSemesterFlag === 0 ? 'N' : 'Y']
 	];
 
 	console.log(HaksuId);
@@ -105,15 +94,8 @@ function CourseDetail({ onClose, HaksuId }) {
 			<ScrollContainer>
 				<Title>{courseDetail.typicalKoreanName}</Title>
 				<MenuList></MenuList>
-				{/* <SubjectContainer>
-					<Subject>
-						{courseDetail.typicalKoreanName} ({courseDetail.typicalEnglishName})
-					</Subject>
-				</SubjectContainer> */}
 				<Subtitle>과목 설명</Subtitle>
 				<ModalContent>{courseDetail.koreanDescription}</ModalContent>
-				{/* <Subject>{courseDetail.typicalEnglishName}</Subject>
-				<ModalContent>{courseDetail.englishDescription}</ModalContent> */}
 				<Subtitle>기본 정보</Subtitle>
 				<TableContent>
 					<TableComponent data={tableData} />

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -6,7 +6,7 @@ import {
 	Subtitle,
 	// Subject,
 	ModalContent,
-	SubjectContainer,
+	//SubjectContainer,
 	TableContent,
 	ScrollContainer
 } from './CourseDetailStyle';
@@ -15,6 +15,7 @@ import TableComponent2 from '../Modal/TableComponent2';
 import Modal from '../Modal/Modal';
 import useField from '../../hooks/useField';
 import MenuList from './MenuList';
+import CompetitionTable from './CompetitionTable';
 
 function CourseDetail({ onClose, HaksuId }) {
 	const [courseDetail, setCourseDetail] = useRecoilState(courseDetailState);
@@ -102,11 +103,11 @@ function CourseDetail({ onClose, HaksuId }) {
 				<Title>{courseDetail.typicalKoreanName}</Title>
 				<MenuList></MenuList>
 
-				<SubjectContainer>
-					{/* <Subject>
+				{/* <SubjectContainer>
+					<Subject>
 						{courseDetail.typicalKoreanName} ({courseDetail.typicalEnglishName})
-					</Subject> */}
-				</SubjectContainer>
+					</Subject>
+				</SubjectContainer> */}
 				<Subtitle>과목 설명</Subtitle>
 				<ModalContent>{courseDetail.koreanDescription}</ModalContent>
 				{/* <Subject>{courseDetail.typicalEnglishName}</Subject>
@@ -119,6 +120,7 @@ function CourseDetail({ onClose, HaksuId }) {
 				<TableContent>
 					<TableComponent2 data={tableData2} />
 				</TableContent>
+				<CompetitionTable></CompetitionTable>
 			</ScrollContainer>
 		</Modal>
 	);

--- a/src/components/CourseDetail/CourseDetailStyle.jsx
+++ b/src/components/CourseDetail/CourseDetailStyle.jsx
@@ -25,20 +25,12 @@ export const SubjectContainer = styled.div`
 	margin-top: 0rem;
 `;
 
-export const Subject = styled.div`
-	color: #036b3f; /* main color */
-	text-align: center;
-	font-size: 1.5rem;
-	margin: 0.5rem 20px;
-	padding-top: 2rem;
-	padding-bottom: 1rem;
-`;
-
 export const Subtitle = styled.h2`
 	color: #036b3f; /* main color */
 	font-size: 1.5rem;
-	margin: 0.5rem 20px;
-	padding-top: 2rem;
+	margin: 0rem 20px;
+	padding-top: 1rem;
+	padding-bottom: 0.5rem;
 `;
 
 export const ModalContent = styled.div`

--- a/src/components/CourseDetail/CourseDetailStyle.jsx
+++ b/src/components/CourseDetail/CourseDetailStyle.jsx
@@ -4,8 +4,8 @@ export const ScrollContainer = styled.div`
 	background-color: transparent;
 	padding: 0rem;
 	border-radius: 8px;
-	max-height: 80vh; /* 내용물의 최대 높이 설정 */
-	overflow-y: auto; /* 세로 스크롤바 표시 */
+	max-height: 80vh;
+	overflow-y: auto;
 	width: 100%;
 `;
 
@@ -26,7 +26,7 @@ export const SubjectContainer = styled.div`
 `;
 
 export const Subtitle = styled.h2`
-	color: #036b3f; /* main color */
+	color: #036b3f;
 	font-size: 1.5rem;
 	margin: 0rem 20px;
 	padding-top: 1rem;

--- a/src/components/CourseDetail/CourseDetailStyle.jsx
+++ b/src/components/CourseDetail/CourseDetailStyle.jsx
@@ -34,13 +34,13 @@ export const Subtitle = styled.h2`
 `;
 
 export const ModalContent = styled.div`
-	font-family: Arial;
+	font-family: 'Pretendard-regular';
 	font-size: 1rem;
 	margin: 10px 20px;
 	line-height: 1.5;
 `;
 
 export const TableContent = styled.div`
-	font-family: Arial;
+	font-family: 'Pretendard-regular';
 	margin: 10px 0;
 `;

--- a/src/components/CourseDetail/CourseDetailStyle.jsx
+++ b/src/components/CourseDetail/CourseDetailStyle.jsx
@@ -37,6 +37,7 @@ export const ModalContent = styled.div`
 	font-family: Arial;
 	font-size: 1rem;
 	margin: 10px 20px;
+	line-height: 1.5;
 `;
 
 export const TableContent = styled.div`

--- a/src/components/CourseDetail/MenuList.jsx
+++ b/src/components/CourseDetail/MenuList.jsx
@@ -40,7 +40,7 @@ const MenuList = () => {
 				<ListItem>과목 설명</ListItem>
 				<ListItem>기본 정보</ListItem>
 				<ListItem>전공 역량</ListItem>
-				<ListItem>수강 인원</ListItem>
+				<ListItem>수강 신청 경쟁률</ListItem>
 			</ListContainer>
 		</Container>
 	);

--- a/src/components/CourseDetail/MenuList.jsx
+++ b/src/components/CourseDetail/MenuList.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+	margin: 10px 20px;
+	background-color: #f0f0f0; /* 배경을 연한 회색으로 설정 */
+	border-radius: 8px; /* 둥근 테두리 */
+	border: 1px solid #f0f0f0; /* 테두리 색상 */
+`;
+
+const Title = styled.div`
+	font-size: 16px;
+	font-weight: bold;
+	border-bottom: 1px solid #ccc;
+	padding: 8px;
+	margin-bottom: 5px;
+	text-align: center;
+`;
+const ListContainer = styled.ul`
+	//list-style-type: none;
+	padding: 0;
+	display: flex;
+	justify-content: space-between;
+	width: 80%;
+	margin: 20px auto; /* 수평 중앙 정렬 */
+`;
+
+const ListItem = styled.li`
+	font-size: 14px;
+	color: #666;
+`;
+
+const MenuList = () => {
+	return (
+		<Container>
+			<Title>목차</Title>
+			<ListContainer>
+				<ListItem>과목 설명</ListItem>
+				<ListItem>기본 정보</ListItem>
+				<ListItem>전공 역량</ListItem>
+				<ListItem>수강 인원</ListItem>
+			</ListContainer>
+		</Container>
+	);
+};
+
+export default MenuList;

--- a/src/components/CourseDetail/MenuList.jsx
+++ b/src/components/CourseDetail/MenuList.jsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 
 const Container = styled.div`
 	margin: 10px 20px;
-	background-color: #f0f0f0; /* 배경을 연한 회색으로 설정 */
-	border-radius: 8px; /* 둥근 테두리 */
-	border: 1px solid #f0f0f0; /* 테두리 색상 */
+	background-color: #f0f0f0;
+	border-radius: 8px;
+	border: 1px solid #f0f0f0;
 `;
 
 const Title = styled.div`
@@ -23,7 +23,7 @@ const ListContainer = styled.ul`
 	display: flex;
 	justify-content: space-between;
 	width: 80%;
-	margin: 20px auto; /* 수평 중앙 정렬 */
+	margin: 20px auto;
 `;
 
 const ListItem = styled.li`

--- a/src/components/CourseDetail/MenuList.jsx
+++ b/src/components/CourseDetail/MenuList.jsx
@@ -9,6 +9,7 @@ const Container = styled.div`
 `;
 
 const Title = styled.div`
+	font-family: 'Pretendard-regular';
 	font-size: 16px;
 	font-weight: bold;
 	border-bottom: 1px solid #ccc;
@@ -17,7 +18,7 @@ const Title = styled.div`
 	text-align: center;
 `;
 const ListContainer = styled.ul`
-	//list-style-type: none;
+	font-family: 'Pretendard-regular';
 	padding: 0;
 	display: flex;
 	justify-content: space-between;
@@ -26,6 +27,7 @@ const ListContainer = styled.ul`
 `;
 
 const ListItem = styled.li`
+	font-family: 'Pretendard-regular';
 	font-size: 14px;
 	color: #666;
 `;

--- a/src/components/Modal/TableComponent.jsx
+++ b/src/components/Modal/TableComponent.jsx
@@ -18,6 +18,7 @@ const StyledTable = styled.table`
 `;
 
 const Td = styled.td`
+	font-family: 'Pretendard-regular';
 	padding: 8px;
 	text-align: center;
 	border: 0.25px solid gray; /* 각 셀의 테두리 */

--- a/src/components/Modal/TableComponent.jsx
+++ b/src/components/Modal/TableComponent.jsx
@@ -14,14 +14,14 @@ const StyledTable = styled.table`
 	margin: 0rem 20px;
 	border-radius: 5px;
 	overflow: hidden;
-	border: 0.5px solid gray; /* 테이블 전체 외곽 테두리 */
+	border: 0.5px solid gray;
 `;
 
 const Td = styled.td`
 	font-family: 'Pretendard-regular';
 	padding: 8px;
 	text-align: center;
-	border: 0.25px solid gray; /* 각 셀의 테두리 */
+	border: 0.25px solid gray;
 	font-size: 14px;
 	width: 8%;
 	background-color: ${({ isHeader }) => (isHeader ? '#036b3f' : 'white')};

--- a/src/components/Modal/TableComponent.jsx
+++ b/src/components/Modal/TableComponent.jsx
@@ -8,46 +8,48 @@ const TableContainer = styled.div`
 `;
 
 const StyledTable = styled.table`
-	border-collapse: collapse;
-	width: 80%;
-	border-radius: 10px;
+	border-collapse: separate;
+	border-spacing: 0;
+	width: 100%;
+	margin: 0rem 20px;
+	border-radius: 5px;
 	overflow: hidden;
-	border: 1px solid #ddd;
-`;
-
-const Th = styled.th`
-	padding: 8px;
-	background-color: #036b3f;
-	text-align: center;
-	color: white;
-	border: 1px solid black; /* 테두리 추가 */
-	font-size: 14px; /* 셀의 폰트 크기 설정 */
-	width: 50%;
+	border: 0.5px solid gray; /* 테이블 전체 외곽 테두리 */
 `;
 
 const Td = styled.td`
 	padding: 8px;
 	text-align: center;
-	border: 1px solid black; /* 테두리 추가 */
-	font-size: 14px; /* 셀의 폰트 크기 설정 */
-	width: 50%;
+	border: 0.25px solid gray; /* 각 셀의 테두리 */
+	font-size: 14px;
+	width: 8%;
+	background-color: ${({ isHeader }) => (isHeader ? '#036b3f' : 'white')};
+	color: ${({ isHeader }) => (isHeader ? 'white' : 'black')};
 `;
 
+// 행렬 변환 함수 (구분, 내용 추가)
+const transposeDataWithHeaders = (data) => {
+	const headers = ['구분', '내용'];
+	const transposed = data[0].map((_, colIndex) => {
+		const newRow = [headers[colIndex], ...data.map((row) => row[colIndex])];
+		return newRow;
+	});
+	return transposed;
+};
+
 const TableComponent = ({ data }) => {
+	const transposedData = transposeDataWithHeaders(data);
+
 	return (
 		<TableContainer>
 			<StyledTable>
-				<thead>
-					<tr>
-						<Th>구분</Th>
-						<Th>내용</Th>
-					</tr>
-				</thead>
 				<tbody>
-					{data.map((row, i) => (
+					{transposedData.map((row, i) => (
 						<tr key={i}>
 							{row.map((cell, j) => (
-								<Td key={j}>{cell}</Td>
+								<Td key={j} isHeader={j === 0}>
+									{cell}
+								</Td>
 							))}
 						</tr>
 					))}

--- a/src/components/Modal/TableComponent2.jsx
+++ b/src/components/Modal/TableComponent2.jsx
@@ -16,6 +16,7 @@ const StyledTable = styled.table`
 `;
 
 const Th = styled.th`
+	font-family: 'Pretendard-regular';
 	padding: 8px;
 	background-color: #036b3f;
 	text-align: center;

--- a/src/components/Modal/TableComponent2.jsx
+++ b/src/components/Modal/TableComponent2.jsx
@@ -27,8 +27,13 @@ const Th = styled.th`
 const Td = styled.td`
 	padding: 8px;
 	text-align: center;
-	font-size: 13px; /* 셀의 폰트 크기 설정 */
-	border: 1px solid black; /* 테두리 추가 */
+	font-size: 13px;
+	border: 1px solid black;
+
+	/* "-" 값일 때 중앙 정렬 */
+	&.centered {
+		text-align: center;
+	}
 
 	/* competencyRemark 열에만 적용할 스타일 */
 	&.remark {
@@ -54,7 +59,7 @@ const TableComponent2 = ({ data }) => {
 						<tr key={i}>
 							<Td>{headers[i]}</Td>
 							{row.map((cell, j) => (
-								<Td key={j} className={j === 1 ? 'remark' : ''}>
+								<Td key={j} className={cell === '-' ? 'centered' : j === 1 ? 'remark' : ''}>
 									{cell}
 								</Td>
 							))}

--- a/src/components/Modal/TableComponent2.jsx
+++ b/src/components/Modal/TableComponent2.jsx
@@ -21,8 +21,8 @@ const Th = styled.th`
 	background-color: #036b3f;
 	text-align: center;
 	color: white;
-	font-size: 14px; /* 헤더의 폰트 크기 설정 */
-	border: 1px solid black; /* 테두리 추가 */
+	font-size: 14px;
+	border: 1px solid black;
 `;
 
 const Td = styled.td`

--- a/src/components/RoadMap/RoadMapCell2/DropdownPortal.jsx
+++ b/src/components/RoadMap/RoadMapCell2/DropdownPortal.jsx
@@ -11,9 +11,8 @@ const DropdownContainer = styled.div`
 	border-radius: 4px;
 	box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
 	z-index: 1000;
-	min-width: 150px;
+	width: 90px; // 고정 너비 설정
 	padding: 10px;
-	width: 1rem;
 `;
 
 const DropdownPortal = ({ x, y, children, onClose, cellRef }) => {

--- a/src/components/RoadMap/RoadMapCell2/DropdownPortal.jsx
+++ b/src/components/RoadMap/RoadMapCell2/DropdownPortal.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import styled from 'styled-components';
+
+const DropdownContainer = styled.div`
+	position: absolute;
+	font-family: 'Pretendard-regular';
+	cursor: pointer;
+	background-color: white;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+	z-index: 1000;
+	min-width: 150px;
+	padding: 10px;
+	width: 1rem;
+`;
+
+const DropdownPortal = ({ x, y, children, onClose, cellRef }) => {
+	const dropdownRef = useRef(null);
+	useEffect(() => {
+		// 창 크기 변경 또는 드롭다운 외부 클릭 시 창 닫음
+		const handleOutsideOrResize = (event) => {
+			if (
+				event.type === 'resize' || // 창 크기 변경
+				(dropdownRef.current &&
+					!dropdownRef.current.contains(event.target) &&
+					cellRef.current && //현재 클릭된 셀은 제외 (따로 처리)
+					!cellRef.current.contains(event.target))
+			) {
+				onClose();
+			}
+		};
+
+		// 외부 클릭과 창 크기 변경 감지
+		document.addEventListener('mousedown', handleOutsideOrResize);
+		window.addEventListener('resize', handleOutsideOrResize);
+
+		return () => {
+			document.removeEventListener('mousedown', handleOutsideOrResize);
+			window.removeEventListener('resize', handleOutsideOrResize);
+		};
+	}, [onClose, cellRef]);
+
+	return ReactDOM.createPortal(
+		<DropdownContainer ref={dropdownRef} style={{ top: y, left: x }} className="dropdown-container">
+			{children}
+		</DropdownContainer>,
+		document.body
+	);
+};
+
+export default DropdownPortal;

--- a/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
+++ b/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
@@ -87,8 +87,8 @@ const Cell2 = ({ cellData, rowIndex, onClick, unclickable, onDropdownToggle, hig
 		const element = event.currentTarget; // 클릭한 셀 요소
 		const rect = element.getBoundingClientRect(); // 요소의 위치 정보
 
-		// 요소 위치 정보를 바탕으로 드롭다운 위치 설정
-		setDropdownPosition({ x: rect.left, y: rect.bottom + window.scrollY }); // 셀 바로 아래 위치 고정
+		// 오른쪽 끝에 -0.5rem 추가하여 드롭다운 위치 설정
+		setDropdownPosition({ x: rect.right - 110, y: rect.bottom + window.scrollY });
 		setIsDropdownOpen((prev) => !prev);
 	};
 

--- a/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
+++ b/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
@@ -84,10 +84,9 @@ const Cell2 = ({ cellData, rowIndex, onClick, unclickable, onDropdownToggle, hig
 	}, [cellData, highlightedCompetency]);
 
 	const handleDropdownToggle = (event) => {
-		const element = event.currentTarget; // 클릭한 셀 요소
-		const rect = element.getBoundingClientRect(); // 요소의 위치 정보
+		const element = event.currentTarget;
+		const rect = element.getBoundingClientRect();
 
-		// 오른쪽 끝에 -0.5rem 추가하여 드롭다운 위치 설정
 		setDropdownPosition({ x: rect.right - 110, y: rect.bottom + window.scrollY });
 		setIsDropdownOpen((prev) => !prev);
 	};
@@ -117,7 +116,6 @@ const Cell2 = ({ cellData, rowIndex, onClick, unclickable, onDropdownToggle, hig
 						onClose={() => setIsDropdownOpen(false)}
 						cellRef={cellRef}
 					>
-						{/* Dropdown 메뉴 항목 추가 */}
 						<DropdownItem onClick={onClickDetailButton}>상세 정보</DropdownItem>
 						<DropdownItem onClick={onClickRoadmapButton}>
 							{cellData.isMyTable ? '내 로드맵에서 제거' : '내 로드맵에 추가'}

--- a/src/components/RoadMap/RoadMapTable.jsx
+++ b/src/components/RoadMap/RoadMapTable.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import Cell from './RoadMapCell';
-import Cell2 from './RoadMapCell2';
+import Cell2 from './RoadMapCell2/RoadMapCell2';
 
 const TableContainer = styled.div`
 	flex: 1;

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -7,7 +7,7 @@ import {
 	totalRoadMapState,
 	courseByCompetencyInSubjectState,
 	courseDetailState,
-	competitionRateState
+	competitionRateState,
 	allFieldDataState,
 	selectedSubjectState,
 	selectedFieldState,
@@ -30,7 +30,6 @@ const useField = () => {
 	const resetSelectedSubjectState = useResetRecoilState(selectedSubjectState);
 	const setSelectedFieldtState = useSetRecoilState(selectedFieldState);
 	const setIsSmallFieldSelectedState = useSetRecoilState(isSmallFieldSelectedState);
-
 
 	const fetchMiddleField = () => {
 		serverApi
@@ -134,7 +133,6 @@ const useField = () => {
 			});
 	};
 
-
 	const fetchAllFields = () => {
 		serverApi
 			.get('/api/v2/field-search/all')
@@ -169,8 +167,7 @@ const useField = () => {
 		fetchCoursesInFields,
 		fetchCoursesInSubject,
 		fetchCourseDetail,
-		resetFields,
-		fetchCompetitionRate
+		fetchCompetitionRate,
 		fetchAllFields,
 		fetchLogFields
 	};

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -7,7 +7,8 @@ import {
 	subjectsInFieldState,
 	totalRoadMapState,
 	courseByCompetencyInSubjectState,
-	courseDetailState
+	courseDetailState,
+	competitionRateState
 } from '../recoils/atoms';
 import useApi from './useApi';
 
@@ -21,6 +22,7 @@ const useField = () => {
 	const setTotalRoadMapState = useSetRecoilState(totalRoadMapState);
 	const setCourseByCompetencyInSubjectState = useSetRecoilState(courseByCompetencyInSubjectState);
 	const setCourseDetailState = useSetRecoilState(courseDetailState);
+	const setCompetitionRateState = useSetRecoilState(competitionRateState);
 
 	const resetFields = (selectedField) => {
 		if (selectedField === 'large' || selectedField === 'all') {
@@ -140,6 +142,17 @@ const useField = () => {
 			});
 	};
 
+	const fetchCompetitionRate = (haksuId) => {
+		serverApi
+			.get(`/api/v1/competition-rate/${haksuId}`)
+			.then((res) => {
+				setCompetitionRateState(res.data);
+			})
+			.catch((error) => {
+				console.error('Error fetching competition rate:', error);
+			});
+	};
+
 	return {
 		fetchLargeField,
 		fetchMiddleField,
@@ -150,7 +163,8 @@ const useField = () => {
 		fetchCoursesInFields,
 		fetchCoursesInSubject,
 		fetchCourseDetail,
-		resetFields
+		resetFields,
+		fetchCompetitionRate
 	};
 };
 

--- a/src/recoils/atoms.js
+++ b/src/recoils/atoms.js
@@ -45,6 +45,11 @@ export const courseDetailState = atom({
 	default: []
 });
 
+export const competitionRateState = atom({
+	key: 'competitionRateState',
+	default: []
+});
+
 export const subjectsInFieldState = atom({
 	key: 'subjectsInFieldState',
 	default: []


### PR DESCRIPTION
## 💡구현 사항



https://github.com/user-attachments/assets/91f07370-a0d5-4335-8f02-82829de146aa





- 목차 추가
- 과목 설명(부제목) 추가 - (국문설명 위에)
- 영문설명 삭제
- 기본정보 돌리기 (가로 세로 전치)
- 기본 정보 필요 없는 내용  삭제
- 수강 경쟁률 확인하기
   -  전체 표 (실 수강인원, 수강 바구니, 수강 정원, 경쟁률)
   - 1,2,3,4학년 버튼으로 인해 변경할 수 있도록 로직 구성
   - 출처 문구 추가 - (* 2023,2024학년도 데이터를 기준으로 산출하였습니다)
- null 값이나 0 - 작대기 채우기

## 🚀 향후 추가

- 목차에서 부제목을 누르면 해당 설명으로 넘어가는 기능 개발

## ❓연관된 이슈

#102 

## 🤔고민 사항

- Api 500 오류가 뜨는 경우가 꽤나 빈번하게 있었습니다 (되는 경우도 많아서 정확히 어떤 원인인지 모르겠습니다)
- 해당 과목 경쟁률 정보가 없어서 그런 것인지? 통신이 안 되고 있는지?
- 이 부분은 확인이 필요할 것 같습니다
