### PR TITLE
[Edit] 직군 검색 버그 수정 및 기타 디자인 요구사항 반영

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -13,6 +13,8 @@ const Container = styled.div`
 const Content = styled.div`
 	padding-top: 5rem;
 	width: 100%;
+	display: flex;
+	justify-content: center;
 `;
 
 const Main = () => {

--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -15,6 +15,7 @@ import SaveButton from '../FloatButton/SaveButton';
 
 const Container = styled.div`
 	min-width: 50rem;
+	width: 95%;
 	display: flex;
 	flex-direction: column;
 `;

--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -15,7 +15,7 @@ import SaveButton from '../FloatButton/SaveButton';
 
 const Container = styled.div`
 	min-width: 50rem;
-	width: 95%;
+	width: 87%;
 	display: flex;
 	flex-direction: column;
 `;

--- a/src/components/Sidebar/FieldInput.jsx
+++ b/src/components/Sidebar/FieldInput.jsx
@@ -99,6 +99,12 @@ const FieldInput = () => {
 
 		setSelectedField(updatedFieldCodeList);
 		setSelectedFieldLog((prevState) => {
+			const isDuplicate = prevState.some(
+				(item) => item.detailField.detailFieldCode === updatedFieldCodeList.detailField.detailFieldCode
+			);
+
+			if (isDuplicate) return prevState;
+
 			const newLog = [...prevState, updatedFieldCodeList];
 			if (newLog.length > 5) {
 				newLog.shift();

--- a/src/components/Sidebar/FieldInput.jsx
+++ b/src/components/Sidebar/FieldInput.jsx
@@ -1,14 +1,15 @@
 import { useEffect } from 'react';
 import styled from 'styled-components';
 import useField from '../../hooks/useField';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import {
 	detailFieldState,
 	middleFieldState,
 	selectedFieldLogState,
 	selectedFieldState,
 	smallFieldState,
-	isSmallFieldSelectedState
+	isSmallFieldSelectedState,
+	selectedSubjectState
 } from '../../recoils/atoms';
 import { Title } from './FieldCategory';
 
@@ -67,6 +68,7 @@ const FieldInput = () => {
 
 	const [selectedField, setSelectedField] = useRecoilState(selectedFieldState);
 	const setSelectedFieldLog = useSetRecoilState(selectedFieldLogState);
+	const resetSelectedSubjectState = useResetRecoilState(selectedSubjectState);
 
 	const [isSmallFieldSelected, setIsSmallFieldSelected] = useRecoilState(isSmallFieldSelectedState);
 
@@ -90,6 +92,8 @@ const FieldInput = () => {
 	};
 
 	const handleDetailFieldClick = (field) => {
+		resetSelectedSubjectState();
+
 		Promise.all([fetchSubjectsInField(field.detailFieldCode), fetchCoursesInFields(field.detailFieldCode)]);
 
 		const updatedFieldCodeList = {

--- a/src/components/Sidebar/SearchBar.jsx
+++ b/src/components/Sidebar/SearchBar.jsx
@@ -90,6 +90,12 @@ const SearchBar = () => {
 
 		fetchLogFields(restructuredFieldData);
 		setSelectedFieldLog((prevState) => {
+			const isDuplicate = prevState.some(
+				(item) => item.detailField.detailFieldCode === restructuredFieldData.detailField.detailFieldCode
+			);
+
+			if (isDuplicate) return prevState;
+
 			const newLog = [...prevState, restructuredFieldData];
 			if (newLog.length > 5) {
 				newLog.shift();

--- a/src/components/Sidebar/SearchBar.jsx
+++ b/src/components/Sidebar/SearchBar.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import useField from '../../hooks/useField';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { allFieldDataState, selectedFieldLogState } from '../../recoils/atoms';
+import { FaSearch } from 'react-icons/fa';
 
 const SearchBarContainer = styled.div`
 	width: 100%;
@@ -11,35 +12,43 @@ const SearchBarContainer = styled.div`
 	position: relative;
 `;
 
-const SearchBarContent = styled.input`
-	width: 93%;
+const SearchBarContent = styled.div`
+	width: 95%;
 	height: 40px;
-	padding: 0 12px;
+	padding: 0 5px;
 	margin-top: 10px;
 	border: 1px solid #ddd;
 	border-radius: 8px;
 	background-color: white;
+
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+`;
+
+const SearchBarInput = styled.input`
+	border: none;
+	border-radius: 8px;
+	background-color: white;
+	width: 100%;
 	font-size: 16px;
 	outline: none;
-	transition: all 0.3s ease;
+`;
 
-	&:focus {
-		border-color: #4a90e2;
-		background-color: #fff;
-		box-shadow: 0 0 5px rgba(74, 144, 226, 0.5);
-	}
+const SearchIcon = styled(FaSearch)`
+	width: 40px;
 `;
 
 const SuggestionsContainer = styled.div`
 	position: absolute;
 	top: 90%;
-	left: 3%;
-	width: 94%;
+	left: 2%;
+	width: 96%;
 	background-color: white;
 	border: 1px solid #ddd;
 	border-radius: 8px;
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-	margin-top: 5px;
+	margin-top: 4px;
 	max-height: 200px;
 	overflow-y: auto;
 	z-index: 1000;
@@ -107,13 +116,16 @@ const SearchBar = () => {
 
 	return (
 		<SearchBarContainer>
-			<SearchBarContent
-				type="text"
-				placeholder="직군을 입력해주세요"
-				value={userInput}
-				onChange={(e) => setUserInput(e.target.value)}
-				onFocus={() => setIsFocused(true)}
-			/>
+			<SearchBarContent>
+				<SearchBarInput
+					type="text"
+					placeholder="직군을 입력해주세요"
+					value={userInput}
+					onChange={(e) => setUserInput(e.target.value)}
+					onFocus={() => setIsFocused(true)}
+				/>
+				<SearchIcon />
+			</SearchBarContent>
 			{isFocused && filteredFields.length > 0 && (
 				<SuggestionsContainer ref={containerRef}>
 					{filteredFields.map((field, index) => (

--- a/src/components/Sidebar/SearchLog.jsx
+++ b/src/components/Sidebar/SearchLog.jsx
@@ -3,7 +3,7 @@ import { Title } from './FieldCategory';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { selectedFieldLogState } from '../../recoils/atoms';
 import useField from '../../hooks/useField';
-import { FaTrashAlt } from 'react-icons/fa';
+import { FaX } from 'react-icons/fa6';
 
 const Container = styled.div`
 	width: 95%;
@@ -62,9 +62,10 @@ const DeleteButton = styled.button`
 	font-size: 16px;
 	display: flex;
 	align-items: center;
+	transition: transform 0.2s ease;
 
 	&:hover {
-		color: #c9302c;
+		transform: scale(1.3);
 	}
 `;
 
@@ -111,7 +112,7 @@ const SearchLog = () => {
 									handleDelete(index);
 								}}
 							>
-								<FaTrashAlt />
+								<FaX />
 							</DeleteButton>
 						</LogItem>
 					);

--- a/src/components/Sidebar/SearchLog.jsx
+++ b/src/components/Sidebar/SearchLog.jsx
@@ -16,6 +16,7 @@ const TitleContainer = styled.div`
 	width: 100%;
 	display: flex;
 	align-items: flex-start;
+	justify-content: space-between;
 `;
 
 const SearchLogContainer = styled.div`
@@ -67,6 +68,20 @@ const DeleteButton = styled.button`
 	}
 `;
 
+const DeleteAllButton = styled.button`
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: #d9534f;
+	font-size: 16px;
+	display: flex;
+	align-items: center;
+
+	&:hover {
+		color: #c9300b;
+	}
+`;
+
 const SearchLog = () => {
 	const selectedFieldLogList = useRecoilValue(selectedFieldLogState);
 	const setSelectedFieldLogList = useSetRecoilState(selectedFieldLogState);
@@ -76,10 +91,13 @@ const SearchLog = () => {
 		setSelectedFieldLogList((prevLog) => prevLog.filter((_, logIndex) => logIndex !== index));
 	};
 
+	const onClickDeleteAllLogs = () => setSelectedFieldLogList([]);
+
 	return (
 		<Container>
 			<TitleContainer>
 				<Title>검색기록</Title>
+				<DeleteAllButton onClick={onClickDeleteAllLogs}>모든 검색기록 삭제</DeleteAllButton>
 			</TitleContainer>
 			<SearchLogContainer>
 				{selectedFieldLogList.map((field, index) => {

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -130,19 +130,27 @@ const useField = () => {
 	};
 
 	const fetchLogFields = async ({ middleField, smallField, detailField }) => {
-		Promise.all([fetchSubjectsInField(detailField.detailFieldCode), fetchCoursesInFields(detailField.detailFieldCode)]);
+		try {
+			const smallFieldResponse = await serverApi.post('/api/v2/field-search/small', middleField);
+			setSmallFieldState(smallFieldResponse.data);
+			setIsSmallFieldSelectedState(true);
 
-		// TODO 세분류 선택시 해당 직군에 대한 학과 및 전체 학과 데이터 가져오는거 개선 필요
-		await fetchSmallField(middleField);
-		await fetchDetailField(smallField);
+			const detailFieldResponse = await serverApi.post('/api/v2/field-search/detail', smallField);
+			setDetailFieldState(detailFieldResponse.data);
+			setSelectedFieldtState({
+				middleField,
+				smallField,
+				detailField
+			});
 
-		setSelectedFieldtState({
-			middleField,
-			smallField,
-			detailField
-		});
-
-		setIsSmallFieldSelectedState(true);
+			const [subjectsResponse] = await Promise.all([
+				serverApi.get(`/api/v1/fields/${detailField.detailFieldCode}/subjects`),
+				fetchCoursesInFields(detailField.detailFieldCode)
+			]);
+			setSubjectsInFieldState(subjectsResponse.data);
+		} catch (error) {
+			console.error('Error fetching log fields:', error);
+		}
 	};
 
 	return {

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -131,6 +131,8 @@ const useField = () => {
 
 	const fetchLogFields = async ({ middleField, smallField, detailField }) => {
 		try {
+			resetSelectedSubjectState();
+
 			const smallFieldResponse = await serverApi.post('/api/v2/field-search/small', middleField);
 			setSmallFieldState(smallFieldResponse.data);
 			setIsSmallFieldSelectedState(true);


### PR DESCRIPTION
## 구현 사항

![image](https://github.com/user-attachments/assets/fae3617a-c4a8-4a73-836b-829ba600d2eb)

- 직군으로 검색한 학과 리스트 출력이 간헐적으로 안되는 버그 수정
- 검색바 돋보기 아이콘 추가
- 검색 기록 아이콘 X 표시로 변경
- 모든 검색 기록 지우기 버튼 추가
- 검색 기록 중복 방지
- 로드맵 컨테이너 width 조절

## 🚀 로직 설명 및 코드 설명

```js
	const fetchLogFields = async ({ middleField, smallField, detailField }) => {
		try {
                        // 선택한 학과 초기화
			resetSelectedSubjectState();

                        // 소분류 데이터 가져오기,
			const smallFieldResponse = await serverApi.post('/api/v2/field-search/small', middleField);
			setSmallFieldState(smallFieldResponse.data);

                        // 직군창 레이아웃 전환을 위한 소분류 선택 상태를 true로 변경
			setIsSmallFieldSelectedState(true);

                        // 세분류 데이터 가져오기
			const detailFieldResponse = await serverApi.post('/api/v2/field-search/detail', smallField);
			setDetailFieldState(detailFieldResponse.data);

                        // 선택 처리를 하기 위해 SelectedFieldState에 값 추가
			setSelectedFieldtState({
				middleField,
				smallField,
				detailField
			});
                        
                        // 세분류 코드로 학과 데이터, 강좌 데이터 받아오기를 Promis.All( )을 이용해 비동기적으로 처리
			const [subjectsResponse] = await Promise.all([
				serverApi.get(`/api/v1/fields/${detailField.detailFieldCode}/subjects`),
				fetchCoursesInFields(detailField.detailFieldCode)
			]);
			setSubjectsInFieldState(subjectsResponse.data);
		} catch (error) {
			console.error('Error fetching log fields:', error);
		}
	};
```

## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 적고싶은 고민 사항이 있다면 추가해주세요
