### PR TITLE
[Edit] 로드맵 컨테이너 관련 버그 수정 및 총 담은 학점 수 보여주기 기능 추가

### DIFF
--- a/src/components/RoadMap/CourseCreditTable.jsx
+++ b/src/components/RoadMap/CourseCreditTable.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 const CourseCreditContainer = styled.div`
-	height: 3rem;
+	height: 6rem;
 	margin: 0rem 1rem 1rem 1rem;
 	display: flex;
 	flex-direction: row;
@@ -12,6 +12,13 @@ const CourseCreditContainer = styled.div`
 	border: 0.05rem solid gray;
 	border-radius: 0.2rem;
 	background-color: #f4f4f4;
+`;
+
+const TitleContainer = styled.div`
+	padding: 0 20px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 `;
 
 const Title = styled.div`
@@ -26,12 +33,18 @@ const Title = styled.div`
 	justify-content: center;
 `;
 
+const CardContainer = styled.div`
+	display: flex;
+	align-items: center;
+	overflow: auto;
+`;
+
 const Card = styled.div`
 	height: 2rem;
 	width: 10rem;
 	min-width: 10rem;
 	font-size: small;
-
+	margin: 0 10px;
 	box-sizing: border-box;
 	border: 0.05rem solid black;
 	border-radius: 0.2rem;
@@ -48,14 +61,21 @@ const CourseCreditTable = ({ courseCreditData }) => {
 		return;
 	}
 
+	let courseCreditSum = courseCreditData.reduce((sum, data) => sum + data.courseCredit, 0);
+
 	return (
 		<CourseCreditContainer>
-			<Title>학과 별 담은 학점</Title>
-			{courseCreditData.map((data, index) => (
-				<Card key={index}>
-					{data.subjectName}: {data.courseCredit}학점
-				</Card>
-			))}
+			<TitleContainer>
+				<Title>총 담은 학점</Title>
+				<Title>{courseCreditSum}</Title>
+			</TitleContainer>
+			<CardContainer>
+				{courseCreditData.map((data, index) => (
+					<Card key={index}>
+						{data.subjectName}: {data.courseCredit}학점
+					</Card>
+				))}
+			</CardContainer>
 		</CourseCreditContainer>
 	);
 };

--- a/src/components/RoadMap/CourseCreditTable.jsx
+++ b/src/components/RoadMap/CourseCreditTable.jsx
@@ -61,7 +61,7 @@ const CourseCreditTable = ({ courseCreditData }) => {
 		return;
 	}
 
-	let courseCreditSum = courseCreditData.reduce((sum, data) => sum + data.courseCredit, 0);
+	const courseCreditSum = courseCreditData.reduce((sum, data) => sum + data.courseCredit, 0);
 
 	return (
 		<CourseCreditContainer>

--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -142,7 +142,7 @@ const RoadMapContainer = () => {
 			const { competencyName, competencyCode } = competency;
 
 			competency.courseGetResponseList.forEach((course) => {
-				const { openingYear, openingSemester, haksuId, name, credit } = course;
+				const { openingYear, openingSemester, haksuId, name, credit, openingSubject } = course;
 				const semesterIndex = openingSemester === '2학기' ? 1 : 0;
 				const openingYear_include9 = openingYear > 4 ? 4 : openingYear;
 				const index = (openingYear_include9 - 1) * 2 + semesterIndex;
@@ -166,7 +166,7 @@ const RoadMapContainer = () => {
 					haksuId: haksuId,
 					courseName: name,
 					courseCredit: credit,
-					subjectName: subjectName,
+					subjectName: openingSubject,
 					competencyCodes: haksuIdToCompetencyMap.get(haksuId),
 					isMyTable: isMyTable
 				};
@@ -201,44 +201,43 @@ const RoadMapContainer = () => {
 
 	// totalRoadMap을 가공하여 totalRoadMapData에 저장
 	useEffect(() => {
-		if (!Array.isArray(totalRoadMap)) {
-			// console.log('totalRoadMap is empty');
-		} else {
-			// totalRoadMap 데이터 가공
-			const updatedRoadMapTableData = JSON.parse(JSON.stringify(defaultTable));
-			totalRoadMap.forEach((course) => {
-				const { openingYear, openingSemester, haksuId, name, credit } = course;
-				const semesterIndex = openingSemester === '2학기' ? 1 : 0;
-				const openingYear_include9 = openingYear > 4 ? 4 : openingYear;
-				const index = (openingYear_include9 - 1) * 2 + semesterIndex;
+		if (!Array.isArray(totalRoadMap)) return;
 
-				updatedRoadMapTableData[index] = [
-					...updatedRoadMapTableData[index],
+		// totalRoadMap 데이터 가공
+		const updatedRoadMapTableData = [...defaultTable];
+		totalRoadMap.forEach((course) => {
+			const { openingYear, openingSemester, haksuId, name, credit, openigSubject } = course;
+			const semesterIndex = openingSemester === '2학기' ? 1 : 0;
+			const openingYear_include9 = openingYear > 4 ? 4 : openingYear;
+			const index = (openingYear_include9 - 1) * 2 + semesterIndex;
+
+			updatedRoadMapTableData[index] = [
+				...updatedRoadMapTableData[index],
+				{
+					haksuId: haksuId,
+					courseName: name,
+					courseCredit: credit,
+					subjectName: openigSubject,
+					competencyCodes: [],
+					isMyTable: false
+				}
+			];
+			if (openingSemester === '1,2학기') {
+				updatedRoadMapTableData[index + 1] = [
+					...updatedRoadMapTableData[index + 1],
 					{
 						haksuId: haksuId,
 						courseName: name,
 						courseCredit: credit,
-						subjectName: subjectName,
+						subjectName: openigSubject,
 						competencyCodes: [],
 						isMyTable: false
 					}
 				];
-				if (openingSemester === '1,2학기') {
-					updatedRoadMapTableData[index + 1] = [
-						...updatedRoadMapTableData[index + 1],
-						{
-							haksuId: haksuId,
-							courseName: name,
-							courseCredit: credit,
-							subjectName: subjectName,
-							competencyCodes: [],
-							isMyTable: false
-						}
-					];
-				}
-			});
-			setTotalRoadMapData(updatedRoadMapTableData);
-		}
+			}
+		});
+
+		setTotalRoadMapData(updatedRoadMapTableData);
 	}, [totalRoadMap]);
 
 	// 내 로드맵 교과목들의 전공역량을 myCompetencyList에 저장
@@ -255,8 +254,10 @@ const RoadMapContainer = () => {
 		setMyCompetencyList(uniqueCompetencyArray);
 	}, [myTableData]);
 
+	// 담은 학점 계산 하는 로직
 	useEffect(() => {
 		const courseCreditMap = {};
+
 		myTableData.forEach((row) => {
 			row.forEach((cellData) => {
 				const subject = cellData.subjectName;


### PR DESCRIPTION
## 구현 사항

https://github.com/user-attachments/assets/abeb9384-bcfc-496e-a770-71f1a2c093df

- 한 학기에 같은 학수 아이디를 가진 과목 중복방지
- 내 로드맵에 추가한 과목에 대해 '실제 학과' 데이터 추가
- 총 담은 학점 수 출력 및 넘침 방지 기능 추가

## 🚀 로직 설명 및 코드 설명
###  학기에 같은 학수 아이디를 가진 과목 중복방지 로직
```js
		if (!haksuIdToCompetencyMap.has(haksuId)) {
			haksuIdToCompetencyMap.set(haksuId, [{ competencyName, competencyCode }]);
		} else {
			const competencies = haksuIdToCompetencyMap.get(haksuId);
			// 중복 역량 방지 후 추가
			if (!competencies.some((comp) => comp.competencyCode === competencyCode)) {
				competencies.push({ competencyName, competencyCode });
			}
			return; // 중복 학수 ID일 경우 이후 로직 스킵
		}
```
- map에 key값으로 학수아이디를 가진다. 이때 현재 학수아이디가 이미 key값으로 존재한다면 해당 학수아이디의 전공역량에 대해서 넣을지 말지 판단한 뒤, 이후 테이블에 추가하지 않는다.
---
### 내 로드맵에 추가한 과목에 대해 '실제 학과' 데이터 추가 로직
```js
		const cellData = {
			haksuId: haksuId,
			courseName: name,
			courseCredit: credit,
			subjectName: openingSubject, // 현재 과목이 실제로 열리는 학과 이름
			competencyCodes: haksuIdToCompetencyMap.get(haksuId),
			isMyTable: isMyTable
		};

```
- course에서 openingSubject 데이터를 cellData에 넣어줌으로써 실제 해당 과목이 열린 학과 정보를 저장했다.
---
### 총 담은 학점 수 출력 및 넘침 방지 기능 추가
```js
     const courseCreditSum = courseCreditData.reduce((sum, data) => sum + data.courseCredit, 0);
```
- reducer 메소드를 사용하여 총 담은 학점 수를 계산하였다.


## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 디자인에 대해 생각해봐야할 것 같습니다
