### PR TITLE
[Fix] 전공역량 하이라이트 기능 픽스

### DIFF
--- a/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
+++ b/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
@@ -89,7 +89,13 @@ const Cell2 = ({ cellData, rowIndex, onClick, unclickable, highlightedCompetency
 
 	useEffect(() => {
 		const competencyCodes = cellData.competencyCodes;
-		setIsHighlighted(Array.isArray(competencyCodes) && competencyCodes.includes(highlightedCompetency));
+		if (Array.isArray(competencyCodes)) {
+			const hasHighlightedCompetency = competencyCodes.some(
+				(competency) => competency.competencyCode === highlightedCompetency
+			);
+
+			setIsHighlighted(hasHighlightedCompetency);
+		}
 
 		const handleClickOutside = (event) => {
 			if (cellRef.current && !cellRef.current.contains(event.target)) {


### PR DESCRIPTION
## 구현 사항
![image](https://github.com/user-attachments/assets/07469685-e443-44a8-8c60-3ef5cff373c2)

## 🚀 로직 설명 및 코드 설명

- 교과목 Cell에 포함된 competencies의 내용이 "전공역량코드 배열"에서 "{전공역량코드, 전공역량이름} 배열"로 수정됨에 따라 발생한 하이라이트 오동작 이슈를 해결했습니다.
