### PR TITLE
[Fix] 상세 모달 내부 디자인 3차 수정

### DIFF
--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -34,8 +34,6 @@ const Table = styled.table`
 const Th = styled.th`
 	font-size: 14px;
 	padding: 10px;
-	// background-color: #f0f0f0;
-	// border: 1px solid #ddd;
 	background-color: #036b3f;
 	color: #ffffff;
 	text-align: center;

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -25,7 +25,7 @@ const TextContainer = styled.div`
 `;
 
 const Table = styled.table`
-	width: 80%;
+	width: 90%;
 	border-collapse: collapse;
 	margin-bottom: 20px;
 	table-layout: fixed;

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -69,7 +69,6 @@ function CourseDetail({ onClose, HaksuId }) {
 	// 데이터가 정상적으로 로드된 경우
 	const additionalInfo = courseDetail.addInformationGetResponse;
 	const competency = courseDetail.competencyInCourseGetResponse;
-	console.log('Course Detail:', courseDetail);
 
 	//API 연결 코드-------------------------
 

--- a/src/components/CourseDetail/MenuList.jsx
+++ b/src/components/CourseDetail/MenuList.jsx
@@ -2,19 +2,61 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Container = styled.div`
-	margin: 10px 20px;
-	background-color: #f0f0f0;
-	border-radius: 8px;
-	border: 1px solid #f0f0f0;
+	background-color: transparent;
+	padding: 0rem;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+`;
+
+// 디자인 후보 #2
+// const TableContainer = styled.div`
+// 	width: 90%;
+// 	border: 1px solid #ddd;
+// 	display: flex;
+// 	flex-direction: column;
+// 	align-items: center;
+// 	justify-content: center;
+// 	margin-top: 10px;
+// 	margin-bottom: 10px;
+// `;
+
+// const Title = styled.div`
+// 	width: 98%;
+// 	background-color: #036b3f;
+// 	color: #ffffff;
+// 	font-size: 16px;
+// 	font-weight: bold;
+// 	border-bottom: 1px solid #ccc;
+// 	padding: 8px;
+// 	margin-bottom: 5px;
+// 	text-align: center;
+// 	display: flex;
+// 	justify-content: center;
+// `;
+
+const TableContainer = styled.div`
+	width: 90%;
+	background-color: rgba(3, 107, 63, 0.1);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	margin-top: 10px;
+	margin-bottom: 10px;
 `;
 
 const Title = styled.div`
+	width: 97%;
 	font-size: 16px;
 	font-weight: bold;
 	border-bottom: 1px solid #ccc;
 	padding: 8px;
 	margin-bottom: 5px;
 	text-align: center;
+	display: flex;
+	justify-content: center;
 `;
 const ListContainer = styled.ul`
 	padding: 0;
@@ -22,24 +64,26 @@ const ListContainer = styled.ul`
 	justify-content: space-between;
 	width: 80%;
 	margin: 20px auto;
+	display: flex; /* 추가 */
 `;
 
 const ListItem = styled.li`
 	font-size: 14px;
-	color: #666;
 	cursor: pointer;
 `;
 
 const MenuList = ({ descriptionHandler, informationHandler, competencyHandler, competitionHandler }) => {
 	return (
 		<Container>
-			<Title>목차</Title>
-			<ListContainer>
-				<ListItem onClick={descriptionHandler}>과목 설명</ListItem>
-				<ListItem onClick={informationHandler}>기본 정보</ListItem>
-				<ListItem onClick={competencyHandler}>전공 역량</ListItem>
-				<ListItem onClick={competitionHandler}>수강 신청 경쟁률</ListItem>
-			</ListContainer>
+			<TableContainer>
+				<Title>목차</Title>
+				<ListContainer>
+					<ListItem onClick={descriptionHandler}>과목 설명</ListItem>
+					<ListItem onClick={informationHandler}>기본 정보</ListItem>
+					<ListItem onClick={competencyHandler}>전공 역량</ListItem>
+					<ListItem onClick={competitionHandler}>수강 신청 경쟁률</ListItem>
+				</ListContainer>
+			</TableContainer>
 		</Container>
 	);
 };

--- a/src/components/CourseDetail/MenuList.jsx
+++ b/src/components/CourseDetail/MenuList.jsx
@@ -65,7 +65,6 @@ const ListContainer = styled.ul`
 	justify-content: space-between;
 	width: 80%;
 	margin: 20px auto;
-	display: flex; /* 추가 */
 `;
 
 const ListItem = styled.li`

--- a/src/components/CourseDetail/MenuList.jsx
+++ b/src/components/CourseDetail/MenuList.jsx
@@ -39,6 +39,7 @@ const Container = styled.div`
 const TableContainer = styled.div`
 	width: 90%;
 	background-color: rgba(3, 107, 63, 0.1);
+	border-radius: 5px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/src/components/Modal/TableComponent.jsx
+++ b/src/components/Modal/TableComponent.jsx
@@ -1,32 +1,54 @@
 import React from 'react';
 import styled from 'styled-components';
 
+const Container = styled.div`
+	background-color: transparent;
+	padding: 0rem;
+	width: 100%;
+`;
+
 const TableContainer = styled.div`
 	display: flex;
 	justify-content: center;
 	margin-top: 20px;
 `;
 
-const StyledTable = styled.table`
-	border-collapse: separate;
-	border-spacing: 0;
-	width: 100%;
-	margin: 0rem 20px;
-	border-radius: 5px;
-	overflow: hidden;
-	border: 0.5px solid gray;
+const Table = styled.table`
+	width: 90%;
+	border-collapse: collapse;
+	margin-bottom: 20px;
+	table-layout: fixed;
 `;
+
+// const Th = styled.th`
+// 	font-size: 14px;
+// 	padding: 10px;
+// 	background-color: #036b3f;
+// 	color: #ffffff;
+// 	text-align: center;
+
+// 	&:nth-child(1) {
+// 		width: 20%;
+// 	}
+// 	&:nth-child(2) {
+// 		width: 30%;
+// 	}
+// 	&:nth-child(3) {
+// 		width: 50%;
+// 	}
+// `;
 
 const Td = styled.td`
-	padding: 8px;
+	font-size: 11.5px;
+	padding: 10px;
+	border: 1px solid #ddd;
 	text-align: center;
-	border: 0.25px solid gray;
-	font-size: 14px;
-	width: 8%;
-	background-color: ${({ isHeader }) => (isHeader ? '#036b3f' : 'white')};
-	color: ${({ isHeader }) => (isHeader ? 'white' : 'black')};
+	width: 10%;
+	&:nth-child(1) {
+		background-color: #036b3f;
+		color: #ffffff;
+	}
 `;
-
 // 행렬 변환 함수 (구분, 내용 추가)
 const transposeDataWithHeaders = (data) => {
 	const headers = ['구분', '내용'];
@@ -41,21 +63,23 @@ const TableComponent = ({ data }) => {
 	const transposedData = transposeDataWithHeaders(data);
 
 	return (
-		<TableContainer>
-			<StyledTable>
-				<tbody>
-					{transposedData.map((row, i) => (
-						<tr key={i}>
-							{row.map((cell, j) => (
-								<Td key={j} isHeader={j === 0}>
-									{cell}
-								</Td>
-							))}
-						</tr>
-					))}
-				</tbody>
-			</StyledTable>
-		</TableContainer>
+		<Container>
+			<TableContainer>
+				<Table>
+					<tbody>
+						{transposedData.map((row, i) => (
+							<tr key={i}>
+								{row.map((cell, j) => (
+									<Td key={j} isHeader={j === 0}>
+										{cell}
+									</Td>
+								))}
+							</tr>
+						))}
+					</tbody>
+				</Table>
+			</TableContainer>
+		</Container>
 	);
 };
 

--- a/src/components/Modal/TableComponent.jsx
+++ b/src/components/Modal/TableComponent.jsx
@@ -20,24 +20,6 @@ const Table = styled.table`
 	table-layout: fixed;
 `;
 
-// const Th = styled.th`
-// 	font-size: 14px;
-// 	padding: 10px;
-// 	background-color: #036b3f;
-// 	color: #ffffff;
-// 	text-align: center;
-
-// 	&:nth-child(1) {
-// 		width: 20%;
-// 	}
-// 	&:nth-child(2) {
-// 		width: 30%;
-// 	}
-// 	&:nth-child(3) {
-// 		width: 50%;
-// 	}
-// `;
-
 const Td = styled.td`
 	font-size: 11.5px;
 	padding: 10px;

--- a/src/components/Modal/TableComponent.jsx
+++ b/src/components/Modal/TableComponent.jsx
@@ -26,6 +26,7 @@ const Td = styled.td`
 	border: 1px solid #ddd;
 	text-align: center;
 	width: 10%;
+	word-wrap: break-word;
 	&:nth-child(1) {
 		background-color: #036b3f;
 		color: #ffffff;

--- a/src/components/Modal/TableComponent2.jsx
+++ b/src/components/Modal/TableComponent2.jsx
@@ -1,43 +1,97 @@
 import React from 'react';
 import styled from 'styled-components';
 
+// const TableContainer = styled.div`
+// 	display: flex;
+// 	justify-content: center;
+// 	margin-top: 20px;
+// `;
+
+// const StyledTable = styled.table`
+// 	border-collapse: collapse;
+// 	width: 90%;
+// 	border-radius: 10px;
+// 	overflow: hidden;
+// 	border: 1px solid #ddd;
+// `;
+
+// const Th = styled.th`
+// 	padding: 8px;
+// 	background-color: #036b3f;
+// 	text-align: center;
+// 	color: white;
+// 	font-size: 14px;
+// 	border: 1px solid black;
+// `;
+
+// const Td = styled.td`
+// 	padding: 8px;
+// 	text-align: center;
+// 	font-size: 13px;
+// 	border: 1px solid black;
+
+// 	/* "-" 값일 때 중앙 정렬 */
+// 	&.centered {
+// 		text-align: center;
+// 	}
+
+// 	/* competencyRemark 열에만 적용할 스타일 */
+// 	&.remark {
+// 		text-align: left;
+// 	}
+// `;
+
+const Container = styled.div`
+	background-color: transparent;
+	padding: 0rem;
+	width: 100%;
+`;
+
 const TableContainer = styled.div`
 	display: flex;
 	justify-content: center;
 	margin-top: 20px;
 `;
 
-const StyledTable = styled.table`
-	border-collapse: collapse;
+const Table = styled.table`
 	width: 90%;
-	border-radius: 10px;
-	overflow: hidden;
-	border: 1px solid #ddd;
+	border-collapse: collapse;
+	margin-bottom: 20px;
+	table-layout: fixed;
 `;
 
 const Th = styled.th`
-	padding: 8px;
-	background-color: #036b3f;
-	text-align: center;
-	color: white;
 	font-size: 14px;
-	border: 1px solid black;
+	padding: 10px;
+	background-color: #036b3f;
+	color: #ffffff;
+	text-align: center;
+
+	&:nth-child(1) {
+		width: 20%;
+	}
+	&:nth-child(2) {
+		width: 30%;
+	}
+	&:nth-child(3) {
+		width: 50%;
+	}
 `;
 
 const Td = styled.td`
-	padding: 8px;
-	text-align: center;
 	font-size: 13px;
-	border: 1px solid black;
+	padding: 10px;
+	border: 1px solid #ddd;
+	text-align: center;
 
-	/* "-" 값일 때 중앙 정렬 */
-	&.centered {
-		text-align: center;
+	&:nth-child(1) {
+		width: 20%;
 	}
-
-	/* competencyRemark 열에만 적용할 스타일 */
-	&.remark {
-		text-align: left;
+	&:nth-child(2) {
+		width: 30%;
+	}
+	&:nth-child(3) {
+		width: 50%;
 	}
 `;
 
@@ -45,29 +99,31 @@ const TableComponent2 = ({ data }) => {
 	const headers = ['주전공역량', '보조전공역량1', '보조전공역량2'];
 
 	return (
-		<TableContainer>
-			<StyledTable>
-				<thead>
-					<tr>
-						<Th>분류</Th>
-						<Th>전공역량명</Th>
-						<Th>전공역량 정의</Th>
-					</tr>
-				</thead>
-				<tbody>
-					{data.map((row, i) => (
-						<tr key={i}>
-							<Td>{headers[i]}</Td>
-							{row.map((cell, j) => (
-								<Td key={j} className={cell === '-' ? 'centered' : j === 1 ? 'remark' : ''}>
-									{cell}
-								</Td>
-							))}
+		<Container>
+			<TableContainer>
+				<Table>
+					<thead>
+						<tr>
+							<Th>분류</Th>
+							<Th>전공역량명</Th>
+							<Th>전공역량 정의</Th>
 						</tr>
-					))}
-				</tbody>
-			</StyledTable>
-		</TableContainer>
+					</thead>
+					<tbody>
+						{data.map((row, i) => (
+							<tr key={i}>
+								<Td>{headers[i]}</Td>
+								{row.map((cell, j) => (
+									<Td key={j} className={cell === '-' ? 'centered' : j === 1 ? 'remark' : ''}>
+										{cell}
+									</Td>
+								))}
+							</tr>
+						))}
+					</tbody>
+				</Table>
+			</TableContainer>
+		</Container>
 	);
 };
 

--- a/src/components/Modal/TableComponent2.jsx
+++ b/src/components/Modal/TableComponent2.jsx
@@ -1,46 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 
-// const TableContainer = styled.div`
-// 	display: flex;
-// 	justify-content: center;
-// 	margin-top: 20px;
-// `;
-
-// const StyledTable = styled.table`
-// 	border-collapse: collapse;
-// 	width: 90%;
-// 	border-radius: 10px;
-// 	overflow: hidden;
-// 	border: 1px solid #ddd;
-// `;
-
-// const Th = styled.th`
-// 	padding: 8px;
-// 	background-color: #036b3f;
-// 	text-align: center;
-// 	color: white;
-// 	font-size: 14px;
-// 	border: 1px solid black;
-// `;
-
-// const Td = styled.td`
-// 	padding: 8px;
-// 	text-align: center;
-// 	font-size: 13px;
-// 	border: 1px solid black;
-
-// 	/* "-" 값일 때 중앙 정렬 */
-// 	&.centered {
-// 		text-align: center;
-// 	}
-
-// 	/* competencyRemark 열에만 적용할 스타일 */
-// 	&.remark {
-// 		text-align: left;
-// 	}
-// `;
-
 const Container = styled.div`
 	background-color: transparent;
 	padding: 0rem;


### PR DESCRIPTION
## 구현 사항


https://github.com/user-attachments/assets/e6d55819-80b1-420c-8343-2350e3079b10
- 표 크기 기존 "전공역량 표"와 통일
- 표의 디자인 기존 "수강신청 경쟁률"과 통일
- 목차의 디자인 수정


## 🚀 로직 설명 및 코드 설명

`word-wrap: break-word;`
- 창의 크기가 작아져서 표의 크기가 작아질 경우 자동 줄바꿈 설정

## 연관된 이슈

close #111 

## 🤔고민 사항

<img width=49% alt="스크린샷 2024-11-14 오후 11 57 26" src="https://github.com/user-attachments/assets/ec02a3a5-0deb-40d1-998c-db5d5a3f2e47">
<img width=49% alt="스크린샷 2024-11-14 오후 11 57 48" src="https://github.com/user-attachments/assets/0d9241d6-9a73-4df5-9ae0-d8e5d1e38067">

> 목차의 표도 같은 디자인으로 통일할 것

- 2가지 버전으로 만들어 놓은 상태
- 1안 : 기존 회색에서 색상만 초록색 개열 바꾼 버전
- 2안 : 아래 3가지 표와 완전히 동일한 상태로 바꾼 버전
- 기획의 확인을 받고 둘 중 선택해서 적용
- 현재는 1안으로 되어있음