### PR TITLE
[FIx] 직군 검색기록 코드 수정

### DIFF
--- a/src/components/Sidebar/FieldInput.jsx
+++ b/src/components/Sidebar/FieldInput.jsx
@@ -127,7 +127,7 @@ const FieldInput = () => {
 
 			const newLog = [updatedFieldCodeList, ...prevState];
 			if (newLog.length > 5) {
-				newLog.shift();
+				newLog.pop();
 			}
 			return newLog;
 		});

--- a/src/components/Sidebar/SearchBar.jsx
+++ b/src/components/Sidebar/SearchBar.jsx
@@ -107,7 +107,7 @@ const SearchBar = () => {
 
 			const newLog = [restructuredFieldData, ...prevState];
 			if (newLog.length > 5) {
-				newLog.shift();
+				newLog.pop();
 			}
 			return newLog;
 		});


### PR DESCRIPTION
## 구현 사항

- 직군에 대한 검색기록 코드를 수정하였습니다.

## 🚀 로직 설명 및 코드 설명

```js
	if (newLog.length > 5) {
		newLog.pop();
	}
```
- 검색기록이 5개가 넘을 시 pop 메소드를 사용하여 가장 오래된 기록을 삭제합니다.
## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 적고싶은 고민 사항이 있다면 추가해주세요
