### PR TITLE
[Fix] 경쟁률 관련 404 에러 처리

### DIFF
--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -135,7 +135,7 @@ const CompetitionTable = ({ haksuId }) => {
 
 	return (
 		<Container>
-			<TextContainer>* 2023,2024학년도 데이터를 기준으로 산출하였습니다.</TextContainer>
+			<TextContainer>* 2024학년도 데이터를 기준으로 산출하였습니다.</TextContainer>
 			{errorMessage ? (
 				<MessageContainer>{errorMessage}</MessageContainer>
 			) : (

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -68,24 +68,37 @@ const GradeButton = styled.button`
 	}
 `;
 
+const MessageContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	margin-top: 20px;
+	font-size: 14px;
+	color: #036b3f;
+`;
+
 const CompetitionTable = ({ haksuId }) => {
 	const { fetchCompetitionRate } = useField();
 	const [selectedGrade, setSelectedGrade] = useState(1);
+	const [errorMessage, setErrorMessage] = useState(null);
 	const setCompetitionRateState = useSetRecoilState(competitionRateState);
 	const competitionData = useRecoilValue(competitionRateState);
 
-	//API 이용
 	useEffect(() => {
 		const loadCompetitionRate = async () => {
 			if (haksuId) {
 				try {
 					const data = await fetchCompetitionRate(haksuId);
 					setCompetitionRateState(data);
+					setErrorMessage(null);
+					console.log('수강 경쟁률:', data);
 				} catch (error) {
-					console.error('Error fetching competition rate:', error);
+					if (error.response && error.response.status === 404) {
+						setErrorMessage('해당 학기 미개설');
+					} else {
+						setErrorMessage('데이터를 불러오는 중 문제가 발생했습니다.');
+					}
 					setCompetitionRateState(null);
 				}
-				console.log(competitionData);
 			}
 		};
 
@@ -123,56 +136,62 @@ const CompetitionTable = ({ haksuId }) => {
 	return (
 		<Container>
 			<TextContainer>* 2023,2024학년도 데이터를 기준으로 산출하였습니다.</TextContainer>
-			{/* 전체 학년 정보 */}
-			<TableContainer>
-				<Table>
-					<thead>
-						<tr>
-							<Th>실 수강인원</Th>
-							<Th>수강 바구니</Th>
-							<Th>수강 정원</Th>
-							<Th>전체 경쟁률</Th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<Td>{competitionData?.totalApplicationNumber || '-'}</Td>
-							<Td>{gradeMapping['total'].capacity}</Td>
-							<Td>{gradeMapping['total'].students}</Td>
-							<Td>{gradeMapping['total'].rate}</Td>
-						</tr>
-					</tbody>
-				</Table>
-			</TableContainer>
+			{errorMessage ? (
+				<MessageContainer>{errorMessage}</MessageContainer>
+			) : (
+				<>
+					{/* 전체 학년 정보 */}
+					<TableContainer>
+						<Table>
+							<thead>
+								<tr>
+									<Th>실 수강인원</Th>
+									<Th>수강 바구니</Th>
+									<Th>수강 정원</Th>
+									<Th>전체 경쟁률</Th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<Td>{competitionData?.totalApplicationNumber || '-'}</Td>
+									<Td>{gradeMapping['total'].capacity}</Td>
+									<Td>{gradeMapping['total'].students}</Td>
+									<Td>{gradeMapping['total'].rate}</Td>
+								</tr>
+							</tbody>
+						</Table>
+					</TableContainer>
 
-			{/* 학년 선택 버튼 */}
-			<ButtonContainer>
-				{[1, 2, 3, 4].map((grade) => (
-					<GradeButton key={grade} active={selectedGrade === grade} onClick={() => setSelectedGrade(grade)}>
-						{grade}학년
-					</GradeButton>
-				))}
-			</ButtonContainer>
+					{/* 학년 선택 버튼 */}
+					<ButtonContainer>
+						{[1, 2, 3, 4].map((grade) => (
+							<GradeButton key={grade} active={selectedGrade === grade} onClick={() => setSelectedGrade(grade)}>
+								{grade}학년
+							</GradeButton>
+						))}
+					</ButtonContainer>
 
-			{/* 선택된 학년 정보 */}
-			<TableContainer>
-				<Table>
-					<thead>
-						<tr>
-							<Th>수강 바구니</Th>
-							<Th>수강 정원</Th>
-							<Th>경쟁률</Th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<Td>{gradeMapping[selectedGrade].capacity}</Td>
-							<Td>{gradeMapping[selectedGrade].students}</Td>
-							<Td>{gradeMapping[selectedGrade].rate}</Td>
-						</tr>
-					</tbody>
-				</Table>
-			</TableContainer>
+					{/* 선택된 학년 정보 */}
+					<TableContainer>
+						<Table>
+							<thead>
+								<tr>
+									<Th>수강 바구니</Th>
+									<Th>수강 정원</Th>
+									<Th>경쟁률</Th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<Td>{gradeMapping[selectedGrade].capacity}</Td>
+									<Td>{gradeMapping[selectedGrade].students}</Td>
+									<Td>{gradeMapping[selectedGrade].rate}</Td>
+								</tr>
+							</tbody>
+						</Table>
+					</TableContainer>
+				</>
+			)}
 		</Container>
 	);
 };

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -7,7 +7,6 @@ import {
 	totalRoadMapState,
 	courseByCompetencyInSubjectState,
 	courseDetailState,
-	competitionRateState,
 	allFieldDataState,
 	selectedSubjectState,
 	selectedFieldState,
@@ -24,7 +23,7 @@ const useField = () => {
 	const setTotalRoadMapState = useSetRecoilState(totalRoadMapState);
 	const setCourseByCompetencyInSubjectState = useSetRecoilState(courseByCompetencyInSubjectState);
 	const setCourseDetailState = useSetRecoilState(courseDetailState);
-	const setCompetitionRateState = useSetRecoilState(competitionRateState);
+	// const setCompetitionRateState = useSetRecoilState(competitionRateState);
 	const setAllFieldState = useSetRecoilState(allFieldDataState);
 	const resetSubjectsInFieldState = useResetRecoilState(subjectsInFieldState);
 	const resetSelectedSubjectState = useResetRecoilState(selectedSubjectState);
@@ -122,15 +121,14 @@ const useField = () => {
 			});
 	};
 
-	const fetchCompetitionRate = (haksuId) => {
-		serverApi
-			.get(`/api/v1/competition-rate/${haksuId}`)
-			.then((res) => {
-				setCompetitionRateState(res.data);
-			})
-			.catch((error) => {
-				console.error('Error fetching competition rate:', error);
-			});
+	const fetchCompetitionRate = async (haksuId) => {
+		try {
+			const res = await serverApi.get(`/api/v1/competition-rate/${haksuId}`);
+			return res.data;
+		} catch (error) {
+			console.error('Error fetching competition rate:', error);
+			throw error;
+		}
 	};
 
 	const fetchAllFields = () => {

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -23,7 +23,6 @@ const useField = () => {
 	const setTotalRoadMapState = useSetRecoilState(totalRoadMapState);
 	const setCourseByCompetencyInSubjectState = useSetRecoilState(courseByCompetencyInSubjectState);
 	const setCourseDetailState = useSetRecoilState(courseDetailState);
-	// const setCompetitionRateState = useSetRecoilState(competitionRateState);
 	const setAllFieldState = useSetRecoilState(allFieldDataState);
 	const resetSubjectsInFieldState = useResetRecoilState(subjectsInFieldState);
 	const resetSelectedSubjectState = useResetRecoilState(selectedSubjectState);


### PR DESCRIPTION
## 💡구현 사항

![image](https://github.com/user-attachments/assets/c896971b-5a0e-4c36-ad99-dd85df31f3bd)

- 404 에러 뜰 경우 해당 학기에 과목이 미개설 되었다고 알려주는 문구 추가
- 2024학년도 데이터만을 이용했기에 이에 맞춰서 문구 수정

## 🚀 로직 설명 및 코드 설명

```
const fetchCompetitionRate = async (haksuId) => {
		try {
			const res = await serverApi.get(`/api/v1/competition-rate/${haksuId}`);
			return res.data;
		} catch (error) {
			console.error('Error fetching competition rate:', error);
			throw error;
		}
	};
```
- 404 에러가 뜰 떄 처리를 따로 해줘야하기 떄문에 동기 함수로 바꾸었습니다
- ErrorMessage의 유무에 따라 테이블을 띄울지 문구를 띄울지 결정
## #️⃣연관된 이슈
close #115 

## 🤔고민 사항

- 이후 APi 수정되면 학기 구분하여 띄우는 작업 진행하겠습니다
