### PR TITLE
[Fix] 폰트 버벅임 이슈 해결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import HowToPage from './pages/HowToPage';
 import AboutUs from './pages/AboutUs';
 import AboutKumap from './pages/AboutKumap';
 import GlobalStyle from './components/GlobalStyle';
+import '../src/font/font.css';
 
 function App() {
 	return (

--- a/src/components/GlobalStyle.jsx
+++ b/src/components/GlobalStyle.jsx
@@ -1,33 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
-import Pretendard_regular from '../font/Pretendard-Regular.otf';
-import Pretendard_semiBold from '../font/Pretendard-SemiBold.otf';
-import Pretendard_bold from '../font/Pretendard-Bold.otf';
 
 const GlobalStyle = createGlobalStyle`
-  @font-face {
-    font-family: 'Pretendard-regular';
-    src: url(${Pretendard_regular}) format('opentype');
-    font-weight: 100;
-    font-style: normal;
-    font-display: swap;
-  }
-
-  @font-face {
-    font-family: 'Pretendard-semiBold';
-    src: url(${Pretendard_semiBold}) format('opentype');
-    font-weight: normal;
-    font-style: normal;
-    font-display: swap;
-  }
-
-  @font-face {
-    font-family: 'Pretendard-bold';
-    src: url(${Pretendard_bold}) format('opentype');
-    font-weight: normal;
-    font-style: normal;
-    font-display: swap;
-  }
-
   body {
     font-family: 'Pretendard-regular';
     margin: 0;

--- a/src/font/font.css
+++ b/src/font/font.css
@@ -1,0 +1,22 @@
+@font-face {
+	font-family: 'Pretendard-regular';
+	src: url('Pretendard-Regular.otf') format('opentype');
+	font-weight: 100;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: 'Pretendard-semiBold';
+	src: url('Pretendard-SemiBold.otf') format('opentype');
+	font-weight: normal;
+	font-style: normal;
+	font-display: swap;
+}
+
+@font-face {
+	font-family: 'Pretendard-bold';
+	src: url('Pretendard-Bold.otf') format('opentype');
+	font-weight: normal;
+	font-style: normal;
+	font-display: swap;
+}


### PR DESCRIPTION
## 구현 사항

수정 전
https://github.com/user-attachments/assets/edbb4030-5645-47b3-a764-063cdda68555

수정 후
https://github.com/user-attachments/assets/d9d83886-674b-4340-9c38-b685825459b4



## 🚀 로직 설명 및 코드 설명

- 이슈 현상: 맥 환경에서는 덜하지만, 윈도우 환경에서 서비스를 실행할 때, 심한 폰트 떨림 현상이 존재함.
- 이슈 발생 이유: styled-components는 스타일이 render 될 때 마다 head 태그 내의 style 태그를 변경하는데, 이로 인해 새로운 스타일이 render 되면 폰트를 재요청 하기 때문에 깜빡임 현상이 발생.
- 해결 방안: GlobalStyle.jsx에서 설정한 font-family를 css 파일로 옮겨서 styled-components 밖에서 리소스를 요청하는 방식으로 해결.
