### PR TITLE
[Fix] design/roadmap-table의 에러 수정

### DIFF
--- a/src/components/RoadMap/CompetencyTable.jsx
+++ b/src/components/RoadMap/CompetencyTable.jsx
@@ -16,7 +16,8 @@ const Container = styled.div`
 `;
 
 const CompetencyContainer = styled.div`
-	width: 100%;
+	width: 96%;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	overflow-y: scroll;

--- a/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
+++ b/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
@@ -95,15 +95,7 @@ const Cell2 = ({ cellData, rowIndex, onClick, unclickable, highlightedCompetency
 	const [isDetailOpen, setIsDetailOpen] = useState(false);
 	const [isHighlighted, setIsHighlighted] = useState(false);
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-	const [cellElement, setCellElement] = useState(0); // 셀의 top 위치를 저장
 	const cellRef = useRef(null);
-
-	useEffect(() => {
-		if (cellRef.current) {
-			const cellElement = cellRef.current;
-			setCellElement(cellElement);
-		}
-	}, []);
 
 	useEffect(() => {
 		const competencyCodes = cellData.competencyCodes;
@@ -131,8 +123,8 @@ const Cell2 = ({ cellData, rowIndex, onClick, unclickable, highlightedCompetency
 		event.stopPropagation();
 		setIsDropdownOpen((prev) => !prev);
 
-		if (onClickSendRef) {
-			onClickSendRef(cellElement);
+		if (onClickSendRef && cellRef.current) {
+			onClickSendRef(cellRef.current);
 		}
 	};
 

--- a/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
+++ b/src/components/RoadMap/RoadMapCell2/RoadMapCell2.jsx
@@ -95,14 +95,13 @@ const Cell2 = ({ cellData, rowIndex, onClick, unclickable, highlightedCompetency
 	const [isDetailOpen, setIsDetailOpen] = useState(false);
 	const [isHighlighted, setIsHighlighted] = useState(false);
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-	const [cellTop, setCellTop] = useState(0); // 셀의 top 위치를 저장
+	const [cellElement, setCellElement] = useState(0); // 셀의 top 위치를 저장
 	const cellRef = useRef(null);
 
 	useEffect(() => {
 		if (cellRef.current) {
 			const cellElement = cellRef.current;
-			const buttonBottom = cellElement.offsetTop;
-			setCellTop(buttonBottom);
+			setCellElement(cellElement);
 		}
 	}, []);
 
@@ -133,7 +132,7 @@ const Cell2 = ({ cellData, rowIndex, onClick, unclickable, highlightedCompetency
 		setIsDropdownOpen((prev) => !prev);
 
 		if (onClickSendRef) {
-			onClickSendRef(cellTop);
+			onClickSendRef(cellElement);
 		}
 	};
 

--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -116,11 +116,13 @@ const RoadMapContainer = () => {
 		}
 	}, [key]);
 
+	useEffect(() => {
+		setRoadMapTableData(JSON.parse(JSON.stringify(defaultTable)));
+	}, [courseByCompetencyInSubject, subjectCode]);
+
 	// courseByCompetencyInSubject을 가공하여 roadMapTableData의 데이터 (직군 또는 학과 변경으로 인한 courseByCompetencyInSubject 변동)
 	useEffect(() => {
 		if (!Array.isArray(courseByCompetencyInSubject)) return;
-
-		setRoadMapTableData(JSON.parse(JSON.stringify(defaultTable)));
 
 		// setCompetencyList(courseByCompetencyInSubject);
 		const competencyList = courseByCompetencyInSubject.map((competency) => ({

--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -116,14 +116,11 @@ const RoadMapContainer = () => {
 		}
 	}, [key]);
 
-	// 다른 전공을 클릭했을 때 테이블 초기화
-	useEffect(() => {
-		setRoadMapTableData(JSON.parse(JSON.stringify(defaultTable)));
-	}, [courseByCompetencyInSubject, subjectCode]);
-
 	// courseByCompetencyInSubject을 가공하여 roadMapTableData의 데이터 (직군 또는 학과 변경으로 인한 courseByCompetencyInSubject 변동)
 	useEffect(() => {
 		if (!Array.isArray(courseByCompetencyInSubject)) return;
+
+		setRoadMapTableData(JSON.parse(JSON.stringify(defaultTable)));
 
 		// setCompetencyList(courseByCompetencyInSubject);
 		const competencyList = courseByCompetencyInSubject.map((competency) => ({
@@ -197,7 +194,9 @@ const RoadMapContainer = () => {
 			return row;
 		});
 
-		setRoadMapTableData(updatedData);
+		setTimeout(() => {
+			setRoadMapTableData(updatedData);
+		}, 10);
 	}, [courseByCompetencyInSubject, myTableData]);
 
 	// totalRoadMap을 가공하여 totalRoadMapData에 저장

--- a/src/components/RoadMap/RoadMapTable.jsx
+++ b/src/components/RoadMap/RoadMapTable.jsx
@@ -60,20 +60,18 @@ const defaultTable = [
 	[{ haksuId: '0', courseName: '4 - 2' }]
 ];
 
+// 스크롤 감지 성능 개선을 위한 함수
+const debounce = (func, delay) => {
+	let timeout;
+	return (...args) => {
+		clearTimeout(timeout);
+		timeout = setTimeout(() => func(...args), delay);
+	};
+};
+
 const RoadMapTable = ({ roadMapTableData, onCellClick, unclickableCells, highlightedCompetency }) => {
 	const containerRef = useRef(null);
 	const [containerScrollTopPosition, setContainerScrollTopPosition] = useState(null);
-
-	useEffect(() => {
-		const container = containerRef.current;
-
-		if (container) {
-			container.addEventListener('scroll', handleScroll);
-			handleScroll();
-
-			return () => container.removeEventListener('scroll', handleScroll);
-		}
-	}, []);
 
 	const handleScroll = () => {
 		if (containerRef.current) {
@@ -82,6 +80,19 @@ const RoadMapTable = ({ roadMapTableData, onCellClick, unclickableCells, highlig
 			setContainerScrollTopPosition(containerOffsetTop);
 		}
 	};
+
+	const debouncedHandleScroll = useRef(debounce(handleScroll, 100)).current;
+
+	useEffect(() => {
+		const container = containerRef.current;
+
+		if (container) {
+			container.addEventListener('scroll', debouncedHandleScroll);
+			debouncedHandleScroll();
+
+			return () => container.removeEventListener('scroll', debouncedHandleScroll);
+		}
+	}, [debouncedHandleScroll]);
 
 	const handleCellClickSendRef = (top) => {
 		const buttonTopPosition = top - 818;

--- a/src/components/RoadMap/RoadMapTable.jsx
+++ b/src/components/RoadMap/RoadMapTable.jsx
@@ -39,6 +39,7 @@ const CourseContainer = styled.div`
 `;
 
 const CourseColumn = styled.div`
+	position: relative;
 	min-width: 0;
 	height: fit-content;
 	margin-bottom: 70px;
@@ -63,20 +64,23 @@ const defaultTable = [
 const RoadMapTable = ({ roadMapTableData, onCellClick, unclickableCells, highlightedCompetency }) => {
 	const containerRef = useRef(null);
 
-	const handleCellClickSendRef = (top) => {
-		if (!containerRef.current) return;
+	const handleCellClickSendRef = (cellElement) => {
+		if (!containerRef.current || !cellElement) return;
 
-		const buttonTopPosition = top - 818;
-		const containerBottomPosition = containerRef.current.scrollTop + 300;
-		if (buttonTopPosition > containerBottomPosition) {
-			if (containerRef.current) {
-				setTimeout(() => {
-					containerRef.current.scrollBy({
-						top: buttonTopPosition - containerBottomPosition,
-						behavior: 'smooth' // 부드러운 스크롤
-					});
-				}, 10);
-			}
+		const cellBottom = cellElement.offsetTop + cellElement.offsetHeight + 80;
+
+		const container = containerRef.current;
+		const containerBottom = container.scrollTop + container.offsetHeight;
+
+		console.log('cellBottom: ', cellBottom, ' containerBottom: ', containerBottom);
+
+		if (cellBottom > containerBottom) {
+			setTimeout(() => {
+				container.scrollBy({
+					top: cellBottom - containerBottom,
+					behavior: 'smooth'
+				});
+			}, 10);
 		}
 	};
 

--- a/src/components/RoadMap/RoadMapTable.jsx
+++ b/src/components/RoadMap/RoadMapTable.jsx
@@ -72,8 +72,6 @@ const RoadMapTable = ({ roadMapTableData, onCellClick, unclickableCells, highlig
 		const container = containerRef.current;
 		const containerBottom = container.scrollTop + container.offsetHeight;
 
-		console.log('cellBottom: ', cellBottom, ' containerBottom: ', containerBottom);
-
 		if (cellBottom > containerBottom) {
 			setTimeout(() => {
 				container.scrollBy({

--- a/src/components/RoadMap/RoadMapTable.jsx
+++ b/src/components/RoadMap/RoadMapTable.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
 import Cell from './RoadMapCell';
 import Cell2 from './RoadMapCell2/RoadMapCell2';
@@ -60,46 +60,14 @@ const defaultTable = [
 	[{ haksuId: '0', courseName: '4 - 2' }]
 ];
 
-// 스크롤 감지 성능 개선을 위한 함수
-const debounce = (func, delay) => {
-	let timeout;
-	return (...args) => {
-		clearTimeout(timeout);
-		timeout = setTimeout(() => func(...args), delay);
-	};
-};
-
 const RoadMapTable = ({ roadMapTableData, onCellClick, unclickableCells, highlightedCompetency }) => {
 	const containerRef = useRef(null);
-	const [containerScrollTopPosition, setContainerScrollTopPosition] = useState(null);
-
-	const handleScroll = () => {
-		if (containerRef.current) {
-			const container = containerRef.current;
-			const containerOffsetTop = container.scrollTop;
-			setContainerScrollTopPosition(containerOffsetTop);
-		}
-	};
-
-	const debouncedHandleScroll = useRef(debounce(handleScroll, 100)).current;
-
-	useEffect(() => {
-		const container = containerRef.current;
-
-		if (container) {
-			container.addEventListener('scroll', debouncedHandleScroll);
-			debouncedHandleScroll();
-
-			return () => container.removeEventListener('scroll', debouncedHandleScroll);
-		}
-	}, [debouncedHandleScroll]);
 
 	const handleCellClickSendRef = (top) => {
-	        if (!containerRef.current) return;
-	        
-	        const containerScrollTopPosition = containerRef.current.scrollTop;
+		if (!containerRef.current) return;
+
 		const buttonTopPosition = top - 818;
-		const containerBottomPosition = containerScrollTopPosition + 300;
+		const containerBottomPosition = containerRef.current.scrollTop + 300;
 		if (buttonTopPosition > containerBottomPosition) {
 			if (containerRef.current) {
 				setTimeout(() => {

--- a/src/components/RoadMap/RoadMapTable.jsx
+++ b/src/components/RoadMap/RoadMapTable.jsx
@@ -95,6 +95,9 @@ const RoadMapTable = ({ roadMapTableData, onCellClick, unclickableCells, highlig
 	}, [debouncedHandleScroll]);
 
 	const handleCellClickSendRef = (top) => {
+	        if (!containerRef.current) return;
+	        
+	        const containerScrollTopPosition = containerRef.current.scrollTop;
 		const buttonTopPosition = top - 818;
 		const containerBottomPosition = containerScrollTopPosition + 300;
 		if (buttonTopPosition > containerBottomPosition) {


### PR DESCRIPTION
## 구현 사항

- 학과 이동 간 발생한 로드맵의 fadeIn 에러 수정
- 전공역량 테이블 간격 수정
- 스크롤 성능 개선

## 🚀 로직 설명 및 코드 설명

- 전체 학과 -> 특정 학과로 넘어갈 때 로드맵 테이블의 fadeIn 애니메이션이 적용되지 않던 에러 수정
- 로드맵 테이블의 fadeIn 애니메이션이 눈에 띄도록 10ms delay 추가
- 전공역량 테이블에서 전공역량 Cell 항목이 많아지면 전공역량 제목 컨테이너가 살짝 줄어드는 에러 수정
- 기존에 스크롤 변동 시 마다 감지 함수를 호출하여 스크롤 버벅임이 심했던 현상을 100ms 간격을 주어 성능 개선
