### PR TITLE
[Design] 사소한 스타일 수정

### DIFF
--- a/src/components/FieldSearchBar/SearchBar.jsx
+++ b/src/components/FieldSearchBar/SearchBar.jsx
@@ -34,7 +34,7 @@ const SearchBarInput = styled.input`
 	border-radius: 8px;
 	background-color: white;
 	width: 100%;
-	font-size: 16px;
+	font-size: 14px;
 	outline: none;
 `;
 

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -11,7 +11,7 @@ const Container = styled.div`
 `;
 
 const Content = styled.div`
-	padding-top: 5rem;
+	padding-top: 30px;
 	width: 100%;
 	display: flex;
 	justify-content: center;

--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -35,7 +35,7 @@ const TitleWrapper = styled.div`
 
 const Title = styled.div`
 	user-select: none;
-	font-size: xx-large;
+	font-size: 25px;
 	font-weight: bolder;
 	color: #036b3f;
 `;


### PR DESCRIPTION
## 구현 사항

<img width="1470" alt="스크린샷 2024-11-28 오후 3 21 57" src="https://github.com/user-attachments/assets/08ff1211-e675-438d-a885-c1377bf27ecd">

- 직군 검색창과 로드맵 컨테이너 간격을 줄였습니다.
- 로드맵 컨테이너 제목 폰트사이즈를 줄였습니다.
- 검색 창 안에 있는 폰트 크기를 14px로 맞췄습니다.

## 🚀 로직 설명 및 코드 설명

- 구현한 코드 설명을 적어주세요

## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 적고싶은 고민 사항이 있다면 추가해주세요
