### PR TITLE
[Feat] 경쟁률 API 학기 구분

### DIFF
--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -10,7 +10,6 @@ const Container = styled.div`
 	padding: 0rem;
 	width: 100%;
 `;
-
 const TableContainer = styled.div`
 	display: flex;
 	justify-content: center;
@@ -68,7 +67,6 @@ const GradeButton = styled.button`
 		color: white;
 	}
 `;
-
 const MessageContainer = styled.div`
 	display: flex;
 	justify-content: center;
@@ -79,10 +77,16 @@ const MessageContainer = styled.div`
 
 const CompetitionTable = ({ haksuId }) => {
 	const { fetchCompetitionRate } = useField();
-	const [selectedGrade, setSelectedGrade] = useState(1);
 	const [errorMessage, setErrorMessage] = useState(null);
 	const setCompetitionRateState = useSetRecoilState(competitionRateState);
 	const competitionData = useRecoilValue(competitionRateState);
+	const [selectedGrades, setSelectedGrades] = useState([]);
+
+	useEffect(() => {
+		if (competitionData && competitionData.length > 0) {
+			setSelectedGrades(Array(competitionData.length).fill(1)); // 학기별로 초기값 설정 (1학년)
+		}
+	}, [competitionData]);
 
 	useEffect(() => {
 		const loadCompetitionRate = async () => {
@@ -105,41 +109,49 @@ const CompetitionTable = ({ haksuId }) => {
 		loadCompetitionRate();
 	}, [haksuId]);
 
-	const gradeMapping = {
-		total: {
-			students: competitionData?.competitionRates?.totalNumber || '-',
-			capacity: competitionData?.competitionRates?.totalCourseBasketNumber || '-',
-			rate: competitionData?.competitionRates?.totalCompetitionRate || '-'
-		},
-		1: {
-			students: competitionData?.competitionRates?.freshmanTotalNumber || '-',
-			capacity: competitionData?.competitionRates?.freshmanCourseBasketNumber || '-',
-			rate: competitionData?.competitionRates?.freshmanCompetitionRate || '-'
-		},
-		2: {
-			students: competitionData?.competitionRates?.sophomoreTotalNumber || '-',
-			capacity: competitionData?.competitionRates?.sophomoreCourseBasketNumber || '-',
-			rate: competitionData?.competitionRates?.sophomoreCompetitionRate || '-'
-		},
-		3: {
-			students: competitionData?.competitionRates?.juniorTotalNumber || '-',
-			capacity: competitionData?.competitionRates?.juniorCourseBasketNumber || '-',
-			rate: competitionData?.competitionRates?.juniorCompetitionRate || '-'
-		},
-		4: {
-			students: competitionData?.competitionRates?.seniorTotalNumber || '-',
-			capacity: competitionData?.competitionRates?.seniorCourseBasketNumber || '-',
-			rate: competitionData?.competitionRates?.seniorCompetitionRate || '-'
-		}
+	const handleGradeChange = (index, grade) => {
+		const updatedGrades = [...selectedGrades];
+		updatedGrades[index] = grade;
+		setSelectedGrades(updatedGrades);
 	};
 
-	return (
-		<Container>
-			<TextContainer>* 2024학년도 데이터를 기준으로 산출하였습니다.</TextContainer>
-			{errorMessage ? (
-				<MessageContainer>{errorMessage}</MessageContainer>
-			) : (
-				<>
+	const renderTablesForSemesters = () => {
+		if (!competitionData || competitionData.length === 0) {
+			return null;
+		}
+
+		return competitionData.map((semesterData, index) => {
+			const gradeMapping = {
+				total: {
+					students: semesterData?.competitionRates?.totalNumber || '-',
+					capacity: semesterData?.competitionRates?.totalCourseBasketNumber || '-',
+					rate: semesterData?.competitionRates?.totalCompetitionRate || '-'
+				},
+				1: {
+					students: semesterData?.competitionRates?.freshmanTotalNumber || '-',
+					capacity: semesterData?.competitionRates?.freshmanCourseBasketNumber || '-',
+					rate: semesterData?.competitionRates?.freshmanCompetitionRate || '-'
+				},
+				2: {
+					students: semesterData?.competitionRates?.sophomoreTotalNumber || '-',
+					capacity: semesterData?.competitionRates?.sophomoreCourseBasketNumber || '-',
+					rate: semesterData?.competitionRates?.sophomoreCompetitionRate || '-'
+				},
+				3: {
+					students: semesterData?.competitionRates?.juniorTotalNumber || '-',
+					capacity: semesterData?.competitionRates?.juniorCourseBasketNumber || '-',
+					rate: semesterData?.competitionRates?.juniorCompetitionRate || '-'
+				},
+				4: {
+					students: semesterData?.competitionRates?.seniorTotalNumber || '-',
+					capacity: semesterData?.competitionRates?.seniorCourseBasketNumber || '-',
+					rate: semesterData?.competitionRates?.seniorCompetitionRate || '-'
+				}
+			};
+
+			return (
+				<div key={index}>
+					<TextContainer>* {semesterData.openingSemester}학기 데이터를 기준으로 산출하였습니다.</TextContainer>
 					{/* 전체 학년 정보 */}
 					<TableContainer>
 						<Table>
@@ -153,7 +165,7 @@ const CompetitionTable = ({ haksuId }) => {
 							</thead>
 							<tbody>
 								<tr>
-									<Td>{competitionData?.totalApplicationNumber || '-'}</Td>
+									<Td>{semesterData.totalApplicationNumber || '-'}</Td>
 									<Td>{gradeMapping['total'].capacity}</Td>
 									<Td>{gradeMapping['total'].students}</Td>
 									<Td>{gradeMapping['total'].rate}</Td>
@@ -165,7 +177,11 @@ const CompetitionTable = ({ haksuId }) => {
 					{/* 학년 선택 버튼 */}
 					<ButtonContainer>
 						{[1, 2, 3, 4].map((grade) => (
-							<GradeButton key={grade} $active={selectedGrade === grade} onClick={() => setSelectedGrade(grade)}>
+							<GradeButton
+								key={grade}
+								$active={selectedGrades[index] === grade}
+								onClick={() => handleGradeChange(index, grade)} // 학기별 상태 변경
+							>
 								{grade}학년
 							</GradeButton>
 						))}
@@ -183,15 +199,21 @@ const CompetitionTable = ({ haksuId }) => {
 							</thead>
 							<tbody>
 								<tr>
-									<Td>{gradeMapping[selectedGrade].capacity}</Td>
-									<Td>{gradeMapping[selectedGrade].students}</Td>
-									<Td>{gradeMapping[selectedGrade].rate}</Td>
+									<Td>{gradeMapping[selectedGrades[index]].capacity}</Td>
+									<Td>{gradeMapping[selectedGrades[index]].students}</Td>
+									<Td>{gradeMapping[selectedGrades[index]].rate}</Td>
 								</tr>
 							</tbody>
 						</Table>
 					</TableContainer>
-				</>
-			)}
+				</div>
+			);
+		});
+	};
+
+	return (
+		<Container>
+			{errorMessage ? <MessageContainer>{errorMessage}</MessageContainer> : renderTablesForSemesters()}
 		</Container>
 	);
 };

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -10,6 +10,7 @@ const Container = styled.div`
 	padding: 0rem;
 	width: 100%;
 `;
+
 const TableContainer = styled.div`
 	display: flex;
 	justify-content: center;
@@ -67,6 +68,7 @@ const GradeButton = styled.button`
 		color: white;
 	}
 `;
+
 const MessageContainer = styled.div`
 	display: flex;
 	justify-content: center;
@@ -74,7 +76,6 @@ const MessageContainer = styled.div`
 	font-size: 14px;
 	color: ${Color.GREEN};
 `;
-
 const CompetitionTable = ({ haksuId }) => {
 	const { fetchCompetitionRate } = useField();
 	const [errorMessage, setErrorMessage] = useState(null);
@@ -83,18 +84,13 @@ const CompetitionTable = ({ haksuId }) => {
 	const [selectedGrades, setSelectedGrades] = useState([]);
 
 	useEffect(() => {
-		if (competitionData && competitionData.length > 0) {
-			setSelectedGrades(Array(competitionData.length).fill(1)); // 학기별로 초기값 설정 (1학년)
-		}
-	}, [competitionData]);
-
-	useEffect(() => {
 		const loadCompetitionRate = async () => {
 			if (haksuId) {
 				try {
 					const data = await fetchCompetitionRate(haksuId);
 					setCompetitionRateState(data);
 					setErrorMessage(null);
+					setSelectedGrades(Array(data.length).fill(1)); // Initialize selectedGrades with '1학년' for each semester
 				} catch (error) {
 					if (error.response && error.response.status === 404) {
 						setErrorMessage('해당 학기 미개설');
@@ -149,9 +145,11 @@ const CompetitionTable = ({ haksuId }) => {
 				}
 			};
 
+			const selectedGrade = selectedGrades[index] || 1; // 기본값 설정
+
 			return (
 				<div key={index}>
-					<TextContainer>* {semesterData.openingSemester}학기 데이터를 기준으로 산출하였습니다.</TextContainer>
+					<TextContainer>* 2024년 {semesterData.openingSemester} 데이터를 기준으로 산출하였습니다.</TextContainer>
 					{/* 전체 학년 정보 */}
 					<TableContainer>
 						<Table>
@@ -180,7 +178,7 @@ const CompetitionTable = ({ haksuId }) => {
 							<GradeButton
 								key={grade}
 								$active={selectedGrades[index] === grade}
-								onClick={() => handleGradeChange(index, grade)} // 학기별 상태 변경
+								onClick={() => handleGradeChange(index, grade)}
 							>
 								{grade}학년
 							</GradeButton>
@@ -199,9 +197,9 @@ const CompetitionTable = ({ haksuId }) => {
 							</thead>
 							<tbody>
 								<tr>
-									<Td>{gradeMapping[selectedGrades[index]].capacity}</Td>
-									<Td>{gradeMapping[selectedGrades[index]].students}</Td>
-									<Td>{gradeMapping[selectedGrades[index]].rate}</Td>
+									<Td>{gradeMapping[selectedGrade]?.capacity || '-'}</Td>
+									<Td>{gradeMapping[selectedGrade]?.students || '-'}</Td>
+									<Td>{gradeMapping[selectedGrade]?.rate || '-'}</Td>
 								</tr>
 							</tbody>
 						</Table>

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -9,6 +9,15 @@ const Container = styled.div`
 	background-color: transparent;
 	padding: 0rem;
 	width: 100%;
+	justify-content: center;
+`;
+
+const Subtitle = styled.h2`
+	color: ${Color.GREEN};
+	font-size: 1.5rem;
+	margin: 0rem 20px;
+	padding-top: 0.5rem;
+	padding-bottom: 0.5rem;
 `;
 
 const TableContainer = styled.div`
@@ -18,19 +27,22 @@ const TableContainer = styled.div`
 `;
 
 const TextContainer = styled.div`
-	margin: 0px 20px;
-	display: flex;
-	justify-content: flex-start;
 	margin-top: 10px;
 	color: #808080;
 	font-size: 0.8rem;
+	display: flex;
+	justify-content: flex-start;
+	gap: 10px;
+	margin: 0 auto 20px;
+	width: 90%;
 `;
-
 const SemesterButtonContainer = styled.div`
 	display: flex;
-	justify-content: center;
-	margin-bottom: 20px;
+	margin-right: 5%;
+	justify-content: flex-end;
+	//margin-bottom: 20px;
 	gap: 10px;
+	//width: 95%;
 `;
 
 const SemesterButton = styled.button`
@@ -99,12 +111,13 @@ const MessageContainer = styled.div`
 	color: ${Color.GREEN};
 `;
 
-const BeigeContainer = styled.div`
-	background-color: white; /* 베이지색 */
-	padding: 0px;
-	border-radius: 10px;
-	padding-top: 10px;
-	margin-top: 10px;
+const SubtitleWithButtons = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	height: auto;
+	margin-bottom: 10px;
 `;
 
 const CompetitionTable = ({ haksuId }) => {
@@ -171,80 +184,81 @@ const CompetitionTable = ({ haksuId }) => {
 
 	return (
 		<Container>
-			{competitionData && competitionData.length > 1 && (
-				<SemesterButtonContainer>
-					{competitionData.map((semester) => (
-						<SemesterButton
-							key={semester.openingSemester}
-							$active={selectedSemester === semester.openingSemester}
-							onClick={() => setSelectedSemester(semester.openingSemester)}
-						>
-							{semester.openingSemester}
-						</SemesterButton>
-					))}
-				</SemesterButtonContainer>
-			)}
+			<SubtitleWithButtons>
+				<Subtitle>수강 신청 경쟁률</Subtitle>
+				{competitionData && competitionData.length > 1 && (
+					<SemesterButtonContainer>
+						{competitionData.map((semester) => (
+							<SemesterButton
+								key={semester.openingSemester}
+								$active={selectedSemester === semester.openingSemester}
+								onClick={() => setSelectedSemester(semester.openingSemester)}
+							>
+								{semester.openingSemester}
+							</SemesterButton>
+						))}
+					</SemesterButtonContainer>
+				)}
+			</SubtitleWithButtons>
 
-			<BeigeContainer>
-				<TextContainer>* 2024학년도 {selectedSemester} 데이터를 기준으로 산출하였습니다.</TextContainer>
+			<TextContainer>* 2024학년도 {selectedSemester} 데이터를 기준으로 산출하였습니다.</TextContainer>
 
-				{errorMessage ? (
-					<MessageContainer>{errorMessage}</MessageContainer>
-				) : filteredData ? (
-					<>
-						{/* 전체 학년 정보 */}
-						<TableContainer>
-							<Table>
-								<thead>
-									<tr>
-										<Th>실 수강인원</Th>
-										<Th>수강 바구니</Th>
-										<Th>수강 정원</Th>
-										<Th>전체 경쟁률</Th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<Td>{filteredData.totalApplicationNumber || '-'}</Td>
-										<Td>{gradeMapping['total'].capacity}</Td>
-										<Td>{gradeMapping['total'].students}</Td>
-										<Td>{gradeMapping['total'].rate}</Td>
-									</tr>
-								</tbody>
-							</Table>
-						</TableContainer>
+			{errorMessage ? (
+				<MessageContainer>{errorMessage}</MessageContainer>
+			) : filteredData ? (
+				<>
+					{/* 전체 학년 정보 */}
+					<TableContainer>
+						<Table>
+							<thead>
+								<tr>
+									<Th>실 수강인원</Th>
+									<Th>수강 바구니</Th>
+									<Th>수강 정원</Th>
+									<Th>전체 경쟁률</Th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<Td>{filteredData.totalApplicationNumber || '-'}</Td>
+									<Td>{gradeMapping['total'].capacity}</Td>
+									<Td>{gradeMapping['total'].students}</Td>
+									<Td>{gradeMapping['total'].rate}</Td>
+								</tr>
+							</tbody>
+						</Table>
+					</TableContainer>
 
-						{/* 학년 선택 버튼 */}
-						<ButtonContainer>
-							{[1, 2, 3, 4].map((grade) => (
-								<GradeButton key={grade} $active={selectedGrade === grade} onClick={() => setSelectedGrade(grade)}>
-									{grade}학년
-								</GradeButton>
-							))}
-						</ButtonContainer>
+					{/* 학년 선택 버튼 */}
+					<ButtonContainer>
+						{[1, 2, 3, 4].map((grade) => (
+							<GradeButton key={grade} $active={selectedGrade === grade} onClick={() => setSelectedGrade(grade)}>
+								{grade}학년
+							</GradeButton>
+						))}
+					</ButtonContainer>
 
-						{/* 선택된 학년 정보 */}
-						<TableContainer>
-							<Table>
-								<thead>
-									<tr>
-										<Th>수강 바구니</Th>
-										<Th>수강 정원</Th>
-										<Th>경쟁률</Th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<Td>{gradeMapping[selectedGrade].capacity}</Td>
-										<Td>{gradeMapping[selectedGrade].students}</Td>
-										<Td>{gradeMapping[selectedGrade].rate}</Td>
-									</tr>
-								</tbody>
-							</Table>
-						</TableContainer>
-					</>
-				) : null}
-			</BeigeContainer>
+					{/* 선택된 학년 정보 */}
+					<TableContainer>
+						<Table>
+							<thead>
+								<tr>
+									<Th>수강 바구니</Th>
+									<Th>수강 정원</Th>
+									<Th>경쟁률</Th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<Td>{gradeMapping[selectedGrade].capacity}</Td>
+									<Td>{gradeMapping[selectedGrade].students}</Td>
+									<Td>{gradeMapping[selectedGrade].rate}</Td>
+								</tr>
+							</tbody>
+						</Table>
+					</TableContainer>
+				</>
+			) : null}
 		</Container>
 	);
 };

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -207,28 +207,6 @@ const CompetitionTable = ({ haksuId }) => {
 				<MessageContainer>{errorMessage}</MessageContainer>
 			) : filteredData ? (
 				<>
-					{/* 전체 학년 정보 */}
-					<TableContainer>
-						<Table>
-							<thead>
-								<tr>
-									<Th>실 수강인원</Th>
-									<Th>수강 바구니</Th>
-									<Th>수강 정원</Th>
-									<Th>전체 경쟁률</Th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<Td>{filteredData.totalApplicationNumber || '-'}</Td>
-									<Td>{gradeMapping['total'].capacity}</Td>
-									<Td>{gradeMapping['total'].students}</Td>
-									<Td>{gradeMapping['total'].rate}</Td>
-								</tr>
-							</tbody>
-						</Table>
-					</TableContainer>
-
 					{/* 학년 선택 버튼 */}
 					<ButtonContainer>
 						{[1, 2, 3, 4].map((grade) => (
@@ -253,6 +231,28 @@ const CompetitionTable = ({ haksuId }) => {
 									<Td>{gradeMapping[selectedGrade].capacity}</Td>
 									<Td>{gradeMapping[selectedGrade].students}</Td>
 									<Td>{gradeMapping[selectedGrade].rate}</Td>
+								</tr>
+							</tbody>
+						</Table>
+					</TableContainer>
+
+					{/* 전체 학년 정보 */}
+					<TableContainer>
+						<Table>
+							<thead>
+								<tr>
+									<Th>실 수강인원</Th>
+									<Th>수강 바구니</Th>
+									<Th>수강 정원</Th>
+									<Th>전체 경쟁률</Th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<Td>{filteredData.totalApplicationNumber || '-'}</Td>
+									<Td>{gradeMapping['total'].capacity}</Td>
+									<Td>{gradeMapping['total'].students}</Td>
+									<Td>{gradeMapping['total'].rate}</Td>
 								</tr>
 							</tbody>
 						</Table>

--- a/src/components/CourseDetail/CompetitionTable.jsx
+++ b/src/components/CourseDetail/CompetitionTable.jsx
@@ -109,7 +109,7 @@ const BeigeContainer = styled.div`
 
 const CompetitionTable = ({ haksuId }) => {
 	const { fetchCompetitionRate } = useField();
-	const [selectedSemester, setSelectedSemester] = useState(null); // 학기 선택 상태 추가
+	const [selectedSemester, setSelectedSemester] = useState(null);
 	const [selectedGrade, setSelectedGrade] = useState(1);
 	const [errorMessage, setErrorMessage] = useState(null);
 	const setCompetitionRateState = useSetRecoilState(competitionRateState);

--- a/src/components/CourseDetail/CourseDetail.jsx
+++ b/src/components/CourseDetail/CourseDetail.jsx
@@ -16,7 +16,6 @@ function CourseDetail({ onClose, HaksuId }) {
 	const descriptionRef = useRef();
 	const informationRef = useRef();
 	const competencyRef = useRef();
-	const competitionnRef = useRef();
 
 	useEffect(() => {
 		const loadData = async () => {
@@ -102,7 +101,6 @@ function CourseDetail({ onClose, HaksuId }) {
 				<TableContent>
 					<TableComponent2 data={tableData2} />
 				</TableContent>
-				<Subtitle ref={competitionnRef}>수강 신청 경쟁률</Subtitle>
 				<CompetitionTable haksuId={HaksuId} />
 			</ScrollContainer>
 		</Modal>


### PR DESCRIPTION
## 구현 사항
![image](https://github.com/user-attachments/assets/2945a11e-707c-4b59-bd92-3b76b38065b3)



- 경쟁률 API 학기 구분하여 받아오기
- 1,2학기 설정할 수 있는 버튼 추가 
- 학기별로 해당 학기 경쟁률 띄워주기
- 제목 옆으로 1,2학기 설정 버튼 위치 이동

## 연관된 이슈

close #148 

## 🤔고민 사항

- 1,2학기를 먼저 선택하고 -> 1,2,3,4학년을 선택하는 것이 원하는 이용경로
- 이대로 사용자가 따라올 수 있을지 의문 (1,2학기 선택과 학년 선택을 구별할 수 있는 수단이 있으면 좋을 것 같음 _-> 피드백으로 해결 완!_
