### PR TITLE
[Feat] URL 공유시 선택한 직군 정보도 같이 공유되는 기능 추가

### DIFF
--- a/src/components/FieldSearchBar/FieldSearchBar.jsx
+++ b/src/components/FieldSearchBar/FieldSearchBar.jsx
@@ -5,6 +5,8 @@ import SearchBar from './SearchBar';
 import FieldInput from './FieldInput';
 import SearchLog from './SearchLog';
 import { Color } from '../../style/Color';
+import { useRecoilState } from 'recoil';
+import { isShowDepartAndLogState } from '../../recoils/atoms';
 
 const FieldSearchBarContainer = styled.div`
 	width: 85%;
@@ -21,7 +23,7 @@ const FieldSearchBarContainer = styled.div`
 `;
 
 const FieldSearchBar = () => {
-	const [isShowDepartAndLog, setIsShowDepartAndLog] = useState(false);
+	const [isShowDepartAndLog, setIsShowDepartAndLog] = useRecoilState(isShowDepartAndLogState);
 	const [isToggleOn, setIsToggleOn] = useState(true);
 
 	return (

--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -375,13 +375,12 @@ const RoadMapContainer = () => {
 	const handleURLButtonClick = () => {
 		const myTableDataString = JSON.stringify(selectedMyTableContents);
 		const encodedMyTableData = encodeData(myTableDataString);
-		console.log(selectedFieldData);
+
 		const selectedFieldDataString = JSON.stringify(selectedFieldData);
 		const encodedSelectedFieldData = encodeData(selectedFieldDataString);
 
 		const baseURL = serverApi.defaults.baseURL;
-		console.log(baseURL);
-		const newUrl = `localhost:3000/road-map?myTableData=${encodedMyTableData}&selectedFieldData=${encodedSelectedFieldData}`;
+		const newUrl = `${baseURL}/road-map?myTableData=${encodedMyTableData}&selectedFieldData=${encodedSelectedFieldData}`;
 		notify_url('주소가 복사되었습니다.');
 
 		navigator.clipboard.writeText(newUrl).catch((error) => console.log(error));

--- a/src/components/RoadMap/RoadMapContainer.jsx
+++ b/src/components/RoadMap/RoadMapContainer.jsx
@@ -11,7 +11,8 @@ import {
 	selectedSubjectState,
 	totalRoadMapState,
 	selectedMyTableContentsState,
-	selectedFieldState
+	selectedFieldState,
+	isShowDepartAndLogState
 } from '../../recoils/atoms';
 import RoadMapContents from './RoadMapContents';
 import CourseCreditTable from './CourseCreditTable';
@@ -111,6 +112,9 @@ const RoadMapContainer = () => {
 	// 선택된 직군 데이터
 	const selectedFieldData = useRecoilValue(selectedFieldState);
 
+	// 학과 및 로그 데이터 보여주는 recoil
+	const setIsShowDepartAndLog = useSetRecoilState(isShowDepartAndLogState);
+
 	const { serverApi } = useApi();
 	const navigate = useNavigate();
 
@@ -154,6 +158,7 @@ const RoadMapContainer = () => {
 
 			const decodedSelectedFieldData = decodeData(selectedFieldData);
 			fetchLogFields(decodedSelectedFieldData);
+			setIsShowDepartAndLog(true);
 		}
 	}, []);
 

--- a/src/recoils/atoms.js
+++ b/src/recoils/atoms.js
@@ -77,3 +77,8 @@ export const selectedMyTableContentsState = atom({
 	key: 'selectedMyTableContentsState',
 	default: []
 });
+
+export const isShowDepartAndLogState = atom({
+	key: 'isShowDepartAndLogState',
+	default: false
+});


### PR DESCRIPTION
## 구현 사항


https://github.com/user-attachments/assets/b8cb8624-b250-4749-8ece-71f0889bccff

- URL 공유시 위에 선택한 직군 정보도 같이 불러와집니다.


## 🚀 로직 설명 및 코드 설명

```js
	// URL을 통한 접속
	useEffect(() => {
		const myTableData = searchParams.get('myTableData');
		const selectedFieldData = searchParams.get('selectedFieldData');
		if (myTableData && selectedFieldData) {
			navigate('/road-map');
			const decodedMyTableData = decodeData(myTableData);
			setSelectedMyTableContentsState(decodedMyTableData);

			const decodedSelectedFieldData = decodeData(selectedFieldData);
			fetchLogFields(decodedSelectedFieldData);
			setIsShowDepartAndLog(true);
		}
	}, []);
```
- URL 정보에 선택한 직군 정보도 추가하였습니다.
- 기존에 검색기록을 불러올때 사용중인 fetchLogFields 함수를 그대로 사용하였습니다.

## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 학과 및 검색기록 보여주는 상태를 전역으로 변경하였는데, 이를 좀 더 깔끔하게 사용할 수 있는 방법이 있을 것 같습니다.

