### PR TITLE
[Fix] URL 공유시 직군 스크롤 추적 안되는 버그 수정

### DIFF
--- a/src/components/FieldSearchBar/FieldInput.jsx
+++ b/src/components/FieldSearchBar/FieldInput.jsx
@@ -116,11 +116,13 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 		fetchMiddleField();
 	}, []);
 
-	if (selectedField) {
-		fieldRefs.middle.current[selectedField.middleField?.middleField]?.scrollIntoView(scrollOption);
-		fieldRefs.small.current[selectedField.smallField?.smallField]?.scrollIntoView(scrollOption);
-		fieldRefs.detail.current[selectedField.detailField?.detailField]?.scrollIntoView(scrollOption);
-	}
+	useEffect(() => {
+		if (selectedField) {
+			fieldRefs.middle.current[selectedField.middleField?.middleField]?.scrollIntoView(scrollOption);
+			fieldRefs.small.current[selectedField.smallField?.smallField]?.scrollIntoView(scrollOption);
+			fieldRefs.detail.current[selectedField.detailField?.detailField]?.scrollIntoView(scrollOption);
+		}
+	}, [selectedField]);
 
 	const handleMiddleFieldClick = async (field) => {
 		await fetchSmallField(field);


### PR DESCRIPTION
## 구현 사항

- URL을 통해 불러온 직군이 자동 스크롤이 이루어지지 않는 버그를 수정했습니다.

## 🚀 로직 설명 및 코드 설명

```js
	useEffect(() => {
		if (selectedField) {
			fieldRefs.middle.current[selectedField.middleField?.middleField]?.scrollIntoView(scrollOption);
			fieldRefs.small.current[selectedField.smallField?.smallField]?.scrollIntoView(scrollOption);
			fieldRefs.detail.current[selectedField.detailField?.detailField]?.scrollIntoView(scrollOption);
		}
	}, [selectedField]);
```
- selectedField를 통해 ref 추가하는 구문을 useEffect로 관리하도록 했습니다.

## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 적고싶은 고민 사항이 있다면 추가해주세요
