### PR TITLE
[Fix] 소개 페이지 디자인 수정

### DIFF
--- a/src/components/AboutKumapContents/AboutCompetencyContents.jsx
+++ b/src/components/AboutKumapContents/AboutCompetencyContents.jsx
@@ -70,11 +70,10 @@ const AboutCompetencyContents = () => {
 				<MainTitle_impact>핵심 능력</MainTitle_impact>
 				<Gap></Gap>
 				<SubContainer>
-					<Description>건국대학교는 역량기반 교육과정을 운영하고 있어서,</Description>
-					<Description>각 전공 교육과정은 전공역량을 기반으로 개발되었어요.</Description>
+					<Description>건국대학교의 전공 교육과정은 전공역량을 기반으로 설계되어 있어요.</Description>
 					<Description></Description>
 					<Description>희망하는 진로 분야와 연관된 전공역량을 파악하고</Description>
-					<Description>필요한 전공역량을 함양할 수 있는 교과목과 전공을 찾는 것이 KUMAP의 큰 목표에요!</Description>
+					<Description>이를 키울 수 있는 교과목과 전공을 찾는 것이 KUMAP의 큰 목표에요!</Description>
 				</SubContainer>
 			</ContentsContainer>
 		</Container>

--- a/src/components/AboutKumapContents/AboutCompetencyContents.jsx
+++ b/src/components/AboutKumapContents/AboutCompetencyContents.jsx
@@ -27,8 +27,8 @@ const HeaderContainer = styled.header`
 `;
 
 const Title = styled.h1`
+	font-family: 'Pretendard-bold';
 	font-size: 4em;
-	font-weight: bold;
 	text-align: left;
 	padding-left: 100px;
 	color: #056a3f;
@@ -36,13 +36,12 @@ const Title = styled.h1`
 
 const MainTitle = styled.div`
 	font-size: 40px;
-	font-weight: 800;
 	color: #056a3f;
 `;
 
 const MainTitle_impact = styled.div`
+	font-family: 'Pretendard-bold';
 	font-size: 50px;
-	font-weight: 800;
 	color: #056a3f;
 `;
 
@@ -60,7 +59,7 @@ const AboutCompetencyContents = () => {
 	return (
 		<>
 			<HeaderContainer>
-				<Title>KUMAP 이란?</Title>
+				<Title>전공역량 이란?</Title>
 			</HeaderContainer>
 			<Container>
 				<MainTitle>전공 분야와 관련된 학문적 지식을 활용함으로써 길러지는</MainTitle>

--- a/src/components/AboutKumapContents/AboutCompetencyContents.jsx
+++ b/src/components/AboutKumapContents/AboutCompetencyContents.jsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 
 const Container = styled.div`
+	z-index: 3;
+`;
+
+const ContentsContainer = styled.div`
 	width: 90%;
 	display: flex;
 	flex-direction: column;
@@ -57,11 +61,11 @@ const Gap = styled.div`
 
 const AboutCompetencyContents = () => {
 	return (
-		<>
+		<Container>
 			<HeaderContainer>
 				<Title>전공역량 이란?</Title>
 			</HeaderContainer>
-			<Container>
+			<ContentsContainer>
 				<MainTitle>전공 분야와 관련된 학문적 지식을 활용함으로써 길러지는</MainTitle>
 				<MainTitle_impact>핵심 능력</MainTitle_impact>
 				<Gap></Gap>
@@ -72,8 +76,8 @@ const AboutCompetencyContents = () => {
 					<Description>희망하는 진로 분야와 연관된 전공역량을 파악하고</Description>
 					<Description>필요한 전공역량을 함양할 수 있는 교과목과 전공을 찾는 것이 KUMAP의 큰 목표에요!</Description>
 				</SubContainer>
-			</Container>
-		</>
+			</ContentsContainer>
+		</Container>
 	);
 };
 

--- a/src/components/AboutKumapContents/AboutKumapContents.jsx
+++ b/src/components/AboutKumapContents/AboutKumapContents.jsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 
 const Container = styled.div`
+	z-index: 3;
+`;
+
+const ContentsContainer = styled.div`
 	width: 90%;
 	display: flex;
 	flex-direction: column;
@@ -57,11 +61,11 @@ const Gap = styled.div`
 
 const AboutKumapContents = () => {
 	return (
-		<>
+		<Container>
 			<HeaderContainer>
 				<Title>KUMAP 이란?</Title>
 			</HeaderContainer>
-			<Container>
+			<ContentsContainer>
 				<MainTitle>원하는 직업과 관련된 수업을 찾아 만드는</MainTitle>
 				<MainTitle_impact>나만의 로드맵</MainTitle_impact>
 				<Gap></Gap>
@@ -71,8 +75,8 @@ const AboutKumapContents = () => {
 					<Description>희망 직업이 요구하는 전공역량을 알아보고,</Description>
 					<Description>필요한 전공역량을 배울 수 있는 수업을 찾아보아요.</Description>
 				</SubContainer>
-			</Container>
-		</>
+			</ContentsContainer>
+		</Container>
 	);
 };
 

--- a/src/components/AboutKumapContents/AboutKumapContents.jsx
+++ b/src/components/AboutKumapContents/AboutKumapContents.jsx
@@ -27,8 +27,8 @@ const HeaderContainer = styled.header`
 `;
 
 const Title = styled.h1`
+	font-family: 'Pretendard-bold';
 	font-size: 4em;
-	font-weight: bold;
 	text-align: left;
 	padding-left: 100px;
 	color: #056a3f;
@@ -36,13 +36,12 @@ const Title = styled.h1`
 
 const MainTitle = styled.div`
 	font-size: 40px;
-	font-weight: 800;
 	color: #056a3f;
 `;
 
 const MainTitle_impact = styled.div`
+	font-family: 'Pretendard-bold';
 	font-size: 50px;
-	font-weight: 800;
 	color: #056a3f;
 `;
 

--- a/src/components/AboutKumapContents/LinkContents.jsx
+++ b/src/components/AboutKumapContents/LinkContents.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled, { css } from 'styled-components';
+import icon_url from '../../img/KU_search_icon.png';
+import { trembleBounce, trembleRotate } from '../../style/Frames';
+import { Color } from '../../style/Color';
+
+const LinkContainer = styled.div`
+	width: 100%;
+	transform: translate(-6rem, 0);
+	padding-top: 8rem;
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+	gap: 4rem;
+`;
+
+const CharacterContainer = styled.div`
+	position: relative;
+	top: -4.5rem;
+	left: 8.5rem;
+	z-index: -1;
+	user-select: none;
+
+	${(props) =>
+		props.$isHovered &&
+		css`
+			animation: ${trembleRotate} 0.4s ease-in-out;
+		`}
+`;
+
+const LinkButton = styled.button`
+	width: 18%;
+	height: 100%;
+	padding: 10px 20px;
+	font-family: 'Pretendard-semiBold';
+	font-size: 30px;
+	color: ${(props) => (props.option === 'white' ? Color.GREEN : 'white')};
+	background-color: ${(props) => (props.option === 'white' ? 'white' : Color.GREEN)};
+	border: 2px solid ${Color.GREEN};
+	border-radius: 20px;
+	cursor: pointer;
+	user-select: none;
+	transition: 0.1s ease-in;
+	&:hover {
+		animation: ${trembleBounce} 0.4s ease-in-out;
+	}
+`;
+const LinkContents = () => {
+	const navigate = useNavigate();
+	const [isHovered, setIsHovered] = useState(false);
+
+	const handleMouseEnter = () => setIsHovered(true);
+	const handleMouseLeave = () => setIsHovered(false);
+	return (
+		<LinkContainer>
+			<CharacterContainer $isHovered={isHovered}>
+				<img alt="Kumap Character" src={icon_url} style={{ width: '7rem' }} />
+			</CharacterContainer>
+
+			<LinkButton
+				onClick={() => navigate('/howtopage')}
+				option={'white'}
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
+			>
+				KUMAP 사용법
+			</LinkButton>
+			<LinkButton onClick={() => navigate('/road-map')} option={'green'}>
+				KUMAP 바로가기!
+			</LinkButton>
+		</LinkContainer>
+	);
+};
+
+export default LinkContents;

--- a/src/components/HomeContents/LinkContents.jsx
+++ b/src/components/HomeContents/LinkContents.jsx
@@ -69,10 +69,10 @@ const LinkContents = () => {
 				onMouseEnter={handleMouseEnter}
 				onMouseLeave={handleMouseLeave}
 			>
-				KUMAP 설명보기
+				KUMAP 이란?
 			</LinkButton>
 			<LinkButton onClick={() => navigate('/road-map')} option={'green'}>
-				KUMAP 바로가기
+				KUMAP 바로가기!
 			</LinkButton>
 		</LinkContainer>
 	);

--- a/src/pages/AboutKumap.jsx
+++ b/src/pages/AboutKumap.jsx
@@ -1,12 +1,14 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
+import MainContainer from '../components/MainContainer';
 import AboutKumapContents from '../components/AboutKumapContents/AboutKumapContents';
 import AboutCompetencyContents from '../components/AboutKumapContents/AboutCompetencyContents';
 import ConclusionContents from '../components/AboutKumapContents/ConclusionContents';
 import LinkContents from '../components/AboutKumapContents/LinkContents';
+import BackgroundContents from '../components/HomeContents/BackgroundContents';
+import ImmergeBackgroundContents from '../components/HomeContents/ImmergeBackgroundContents';
 import Footer from '../components/Footer/Footer';
-import { Header, SectionsContainer } from 'react-fullpage';
-import HeaderBar from '../components/HeaderBar';
+import { SectionsContainer } from 'react-fullpage';
 import { fullPageOptions } from './AboutUs';
 
 const SubContainer = styled.div`
@@ -23,7 +25,6 @@ const LastContainer = styled.div`
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	background-color: white;
 `;
 
 const AboutKumap = () => {
@@ -32,10 +33,9 @@ const AboutKumap = () => {
 	}, []);
 
 	return (
-		<>
-			<Header>
-				<HeaderBar />
-			</Header>
+		<MainContainer>
+			<BackgroundContents />
+			<ImmergeBackgroundContents />
 			<SectionsContainer {...fullPageOptions}>
 				<SubContainer>
 					<AboutKumapContents />
@@ -51,7 +51,7 @@ const AboutKumap = () => {
 					<Footer />
 				</SubContainer>
 			</SectionsContainer>
-		</>
+		</MainContainer>
 	);
 };
 

--- a/src/pages/AboutKumap.jsx
+++ b/src/pages/AboutKumap.jsx
@@ -1,13 +1,13 @@
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 import AboutKumapContents from '../components/AboutKumapContents/AboutKumapContents';
 import AboutCompetencyContents from '../components/AboutKumapContents/AboutCompetencyContents';
 import ConclusionContents from '../components/AboutKumapContents/ConclusionContents';
+import LinkContents from '../components/AboutKumapContents/LinkContents';
 import Footer from '../components/Footer/Footer';
 import { Header, SectionsContainer } from 'react-fullpage';
 import HeaderBar from '../components/HeaderBar';
 import { fullPageOptions } from './AboutUs';
-import { Color } from '../style/Color';
 
 const SubContainer = styled.div`
 	width: 100%;
@@ -18,7 +18,7 @@ const SubContainer = styled.div`
 `;
 
 const LastContainer = styled.div`
-	height: 85vh;
+	height: 80vh;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -26,33 +26,11 @@ const LastContainer = styled.div`
 	background-color: white;
 `;
 
-const LinkContainer = styled.div`
-	gap: 25px;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
-	flex-grow: 1;
-`;
-
-const LinkButton = styled.button`
-	width: 400px;
-	height: 100px;
-	padding: 10px 20px;
-	font-size: 30px;
-	color: ${(props) => (props.option === 'white' ? Color.GREEN : 'white')};
-	background-color: ${(props) => (props.option === 'white' ? '#eeeeee' : Color.GREEN)};
-	border: none;
-	border-radius: 20px;
-	cursor: pointer;
-	transition: 0.1s ease-in;
-	&:hover {
-		background-color: ${(props) => (props.option === 'white' ? '#d3d3d3' : '#02472a')};
-	}
-`;
-
 const AboutKumap = () => {
-	const navigate = useNavigate();
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, []);
+
 	return (
 		<>
 			<Header>
@@ -68,14 +46,7 @@ const AboutKumap = () => {
 				<SubContainer>
 					<LastContainer>
 						<ConclusionContents />
-						<LinkContainer>
-							<LinkButton onClick={() => navigate('/howtopage')} option={'white'}>
-								KUMAP 사용법
-							</LinkButton>
-							<LinkButton onClick={() => navigate('/road-map')} option={'green'}>
-								KUMAP 바로가기
-							</LinkButton>
-						</LinkContainer>
+						<LinkContents />
 					</LastContainer>
 					<Footer />
 				</SubContainer>


### PR DESCRIPTION
## 구현 사항

![image](https://github.com/user-attachments/assets/ea22b979-b68f-4b4c-8fc3-c93a06143230)
![image](https://github.com/user-attachments/assets/869b7caf-0954-41c5-b388-f6fd7f78e46b)
![image](https://github.com/user-attachments/assets/69cfb460-1bf7-46b7-9e9e-bb50fb36a64a)
![image](https://github.com/user-attachments/assets/8a4c1636-b48f-4520-9444-7731f60b0704)

## 🚀 로직 설명 및 코드 설명

- 기존 "KUMAP 설명보기" 버튼의 문구를 "KUMAP 이란?" 으로 수정하였습니다. (문구가 설명인지 소개인지 모호하다는 지영쌤의 의견 반영)
- 소개 페이지의 디자인을 수정했습니다.
- 소개 페이지의 문구를 수정했습니다.
- 다른 페이지에서 스크롤이 내려간 상태로 페이지를 이동하면 섹션이 애매하게 잘리던 이슈를 페이지 렌더링 시 스크롤을 가장 상단으로 올리는 처리를 통해 해결하였습니다.

## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 적고싶은 고민 사항이 있다면 추가해주세요
