### PR TITLE
[Design] 헤더 분리 및 푸터 height 통일

### DIFF
--- a/src/components/AboutKumapContents/AboutCompetencyContents.jsx
+++ b/src/components/AboutKumapContents/AboutCompetencyContents.jsx
@@ -28,7 +28,7 @@ const SubContainer = styled.div`
 const HeaderContainer = styled.header`
 	width: fit-content;
 	align-self: flex-start;
-	padding-top: 100px;
+	padding-top: 50px;
 	text-align: center;
 	margin-bottom: 0;
 `;

--- a/src/components/AboutKumapContents/AboutKumapContents.jsx
+++ b/src/components/AboutKumapContents/AboutKumapContents.jsx
@@ -28,7 +28,7 @@ const SubContainer = styled.div`
 const HeaderContainer = styled.header`
 	width: fit-content;
 	align-self: flex-start;
-	padding-top: 100px;
+	padding-top: 50px;
 	text-align: center;
 	margin-bottom: 0;
 `;

--- a/src/components/AboutKumapContents/ConclusionContents.jsx
+++ b/src/components/AboutKumapContents/ConclusionContents.jsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 const Container = styled.div`
-	width: 90%;
+	width: 100%;
+	height: 100%
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/src/components/AboutKumapContents/ConclusionContents.jsx
+++ b/src/components/AboutKumapContents/ConclusionContents.jsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 const Container = styled.div`
 	width: 90%;
 	display: flex;
-	margin-top: 5%;
 	flex-direction: column;
 	justify-content: center;
 	align-self: center;

--- a/src/components/AboutUsContents/AboutUsContens.jsx
+++ b/src/components/AboutUsContents/AboutUsContens.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const Container = styled.div`
 	width: 100%;
-	height: 100vh;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/src/components/AboutUsContents/IntroductionContents.jsx
+++ b/src/components/AboutUsContents/IntroductionContents.jsx
@@ -5,7 +5,7 @@ import Footer from '../Footer/Footer';
 
 const Container = styled.div`
 	width: 100%;
-	height: 100vh;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/src/components/AboutUsContents/IntroductionProfileContents.jsx
+++ b/src/components/AboutUsContents/IntroductionProfileContents.jsx
@@ -8,8 +8,8 @@ import SungjongProfile from '../../img/SungjongProfile.png';
 import SeungraeProfile from '../../img/SeungraeProfile.png';
 
 const Container = styled.div`
-	height: 60vh;
 	display: flex;
+	flex: 1;
 	flex-direction: row;
 	justify-content: center;
 	align-items: center;

--- a/src/components/AboutUsContents/IntroductionTitleContent.jsx
+++ b/src/components/AboutUsContents/IntroductionTitleContent.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const TitleContainer = styled.div`
-	height: 20vh;
+	height: 15vh;
 	width: 80%;
 	display: flex;
 	flex-direction: column;

--- a/src/components/AboutUsContents/LogoContents.jsx
+++ b/src/components/AboutUsContents/LogoContents.jsx
@@ -3,7 +3,7 @@ import { SubTitle } from './AboutUsContens';
 
 const LogoContainer = styled.div`
 	width: 100%;
-	height: 100vh;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/src/components/FieldSearchBar/FieldSearchBar.jsx
+++ b/src/components/FieldSearchBar/FieldSearchBar.jsx
@@ -12,7 +12,7 @@ const FieldSearchBarContainer = styled.div`
 	width: 85%;
 	gap: 10px;
 	min-width: 600px;
-	margin-top: 5rem;
+	margin-top: 30px;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -3,8 +3,11 @@ import styled from 'styled-components';
 import FieldSearchBar from './FieldSearchBar/FieldSearchBar';
 import RoadMapContainer from './RoadMap/RoadMapContainer';
 import TutorialModal from './Tutorial/TutorialModal';
+
 const Container = styled.div`
-	width: 100%;
+	position: relative;
+	height: 100%;
+	overflow-y: scroll;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -57,15 +60,13 @@ const Main = () => {
 	};
 
 	return (
-		<>
-			<Container>
-				{showModal && <TutorialModal onClose={handleCloseModal} onDismissForAWeek={handleDismissForAWeek} />}
-				<FieldSearchBar show={showFieldSearchBar} toggleFieldSearchBar={toggleFieldSearchBar} />
-				<Content>
-					<RoadMapContainer />
-				</Content>
-			</Container>
-		</>
+		<Container>
+			{showModal && <TutorialModal onClose={handleCloseModal} onDismissForAWeek={handleDismissForAWeek} />}
+			<FieldSearchBar show={showFieldSearchBar} toggleFieldSearchBar={toggleFieldSearchBar} />
+			<Content>
+				<RoadMapContainer />
+			</Content>
+		</Container>
 	);
 };
 

--- a/src/components/MainContainer.jsx
+++ b/src/components/MainContainer.jsx
@@ -6,13 +6,23 @@ const Container = styled.div`
 	width: 100%;
 	min-height: 100vh;
 	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+`;
+
+const ContentsContainer = styled.div`
+	min-width: 1200px;
+	width: 100%;
+	height: calc(100vh - 70px);
+	overflow: hidden;
 `;
 
 const MainContainer = ({ children }) => {
 	return (
 		<Container>
 			<HeaderBar />
-			{children}
+			<ContentsContainer>{children}</ContentsContainer>
 		</Container>
 	);
 };

--- a/src/pages/AboutKumap.jsx
+++ b/src/pages/AboutKumap.jsx
@@ -31,7 +31,7 @@ const SubContainer = styled.div`
 
 const LastContainer = styled.div`
 	width: 100%;
-	height: 100%;
+	flex: 1;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/src/pages/AboutKumap.jsx
+++ b/src/pages/AboutKumap.jsx
@@ -11,19 +11,19 @@ import Footer from '../components/Footer/Footer';
 const Container = styled.div`
 	position: relative;
 	width: 100%;
-	height: 100vh;
+	height: 100%;
 	overflow: hidden;
 `;
 
 const ContentsContainer = styled.div`
 	width: 100%;
-	height: 100vh;
+	height: 100%;
 	overflow-y: auto;
 `;
 
 const SubContainer = styled.div`
 	width: 100%;
-	height: 100vh;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -31,7 +31,7 @@ const SubContainer = styled.div`
 
 const LastContainer = styled.div`
 	width: 100%;
-	height: 85vh;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/src/pages/AboutUs.jsx
+++ b/src/pages/AboutUs.jsx
@@ -8,13 +8,13 @@ import BackgroundContents from '../components/AboutUsContents/BackgroundContents
 const Container = styled.div`
 	position: relative;
 	width: 100%;
-	height: 100vh;
+	height: 100%;
 	overflow: hidden;
 `;
 
 const ContentsContainer = styled.div`
 	width: 100%;
-	height: 100vh;
+	height: 100%;
 	overflow-y: auto;
 `;
 

--- a/src/pages/RoadMap.jsx
+++ b/src/pages/RoadMap.jsx
@@ -1,12 +1,11 @@
+import MainContainer from '../components/MainContainer';
 import Main from '../components/Main';
-import HeaderBar from '../components/HeaderBar';
 
 function RoadMap() {
 	return (
-		<>
-			<HeaderBar />
+		<MainContainer>
 			<Main />
-		</>
+		</MainContainer>
 	);
 }
 


### PR DESCRIPTION
## 구현 사항
![image](https://github.com/user-attachments/assets/a7ee0960-535b-4102-90d9-ecd94188fd98)
![image](https://github.com/user-attachments/assets/e399262e-5927-4053-826a-f1ecd78283b8)
![image](https://github.com/user-attachments/assets/00ee0bb4-72a5-4c21-9319-6c8c8220fd9b)

- 소개 페이지, KUMAP 페이지, AboutUs 페이지에서 스크롤이 헤더를 침범하지 않도록 수정하였습니다.
- Footer의 height를 통일하였습니다.

## 🚀 로직 설명 및 코드 설명

- 소개 페이지, KUMAP 페이지, AboutUs 페이지의 헤더와 내용 컨테이너를 분리하였습니다.
- 소개 페이지, AboutUs 페이지에서 Footer가 동일하게 20vh를 가지도록 수정했습니다.

## 연관된 이슈

- 연관된 이슈가 있다면 추가해주세요

## 🤔고민 사항

- 적고싶은 고민 사항이 있다면 추가해주세요
