### PR TITLE
[Fix] z-index를 수정하여 레이어 이슈 해결

### DIFF
--- a/src/components/AboutKumapContents/AboutCompetencyContents.jsx
+++ b/src/components/AboutKumapContents/AboutCompetencyContents.jsx
@@ -4,7 +4,6 @@ const Container = styled.div`
 	width: 100%;
 	display: flex;
 	flex-direction: column;
-	z-index: 3;
 `;
 
 const ContentsContainer = styled.div`

--- a/src/components/AboutKumapContents/AboutKumapContents.jsx
+++ b/src/components/AboutKumapContents/AboutKumapContents.jsx
@@ -4,7 +4,6 @@ const Container = styled.div`
 	width: 100%;
 	display: flex;
 	flex-direction: column;
-	z-index: 3;
 `;
 
 const ContentsContainer = styled.div`

--- a/src/components/AboutUsContents/AboutUsContens.jsx
+++ b/src/components/AboutUsContents/AboutUsContens.jsx
@@ -17,7 +17,6 @@ const ContentsContainer = styled.div`
 	justify-content: center;
 	align-items: center;
 	gap: 20px;
-	z-index: 3;
 `;
 
 const MainTitle = styled.div`

--- a/src/components/AboutUsContents/BackgroundContents.jsx
+++ b/src/components/AboutUsContents/BackgroundContents.jsx
@@ -5,6 +5,7 @@ import CircleStyle from '../../style/CircleStyle';
 const BackgroundContainer = styled.div`
 	opacity: 0;
 	animation: ${fadeIn} 0.5s ease-in-out forwards;
+	z-index: -1;
 `;
 
 function BackgroundContents() {
@@ -16,12 +17,26 @@ function BackgroundContents() {
 				top={'-21rem'}
 				left={'-18%'}
 				time={'8'}
-				zIndex={2}
+				zIndex={-1}
 			/>
-			<CircleStyle color={'rgba(237, 248, 241, 0.7)'} size={'16rem'} top={'18rem'} left={'12%'} time={'6'} zIndex={0} />
-			<CircleStyle color={'rgba(214, 239, 224, 0.6)'} size={'10rem'} top={'15rem'} left={'23%'} time={'5'} zIndex={0} />
-			<CircleStyle color={'rgba(221, 242, 229, 0.8)'} size={'6rem'} top={'16rem'} left={'70%'} time={'4'} zIndex={0} />
-			<CircleStyle color={'rgba(232, 247, 238, 0.7)'} size={'25rem'} top={'3rem'} left={'74%'} time={'7'} zIndex={0} />
+			<CircleStyle
+				color={'rgba(237, 248, 241, 0.7)'}
+				size={'16rem'}
+				top={'18rem'}
+				left={'12%'}
+				time={'6'}
+				zIndex={-1}
+			/>
+			<CircleStyle
+				color={'rgba(214, 239, 224, 0.6)'}
+				size={'10rem'}
+				top={'15rem'}
+				left={'23%'}
+				time={'5'}
+				zIndex={-1}
+			/>
+			<CircleStyle color={'rgba(221, 242, 229, 0.8)'} size={'6rem'} top={'16rem'} left={'70%'} time={'4'} zIndex={-1} />
+			<CircleStyle color={'rgba(232, 247, 238, 0.7)'} size={'25rem'} top={'3rem'} left={'74%'} time={'7'} zIndex={-1} />
 		</BackgroundContainer>
 	);
 }

--- a/src/components/AboutUsContents/IntroductionProfileContents.jsx
+++ b/src/components/AboutUsContents/IntroductionProfileContents.jsx
@@ -15,7 +15,6 @@ const Container = styled.div`
 	align-items: center;
 	width: 100%;
 	background-color: rgba(214, 239, 224, 0.4);
-	z-index: 3;
 `;
 
 const IntroductionProfileContents = () => {

--- a/src/components/AboutUsContents/IntroductionTitleContent.jsx
+++ b/src/components/AboutUsContents/IntroductionTitleContent.jsx
@@ -9,7 +9,6 @@ const TitleContainer = styled.div`
 	justify-content: center;
 	margin: 40px 0;
 	gap: 5px;
-	z-index: 3;
 `;
 
 const HeaderTitle = styled.div`

--- a/src/components/AboutUsContents/LogoContents.jsx
+++ b/src/components/AboutUsContents/LogoContents.jsx
@@ -9,7 +9,6 @@ const LogoContainer = styled.div`
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	z-index: 3;
 `;
 
 const KusdLogo = styled.img.attrs({ src: kusdLogo, alt: '학생개발팀 로고' })`

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -10,7 +10,7 @@ const Container = styled.div`
 	width: 100%;
 	height: ${({ $customHeight }) => $customHeight || '150px'};
 	background-color: #0a3711;
-	z-index: 3;
+	z-index: 1;
 `;
 
 const SubContainer = styled.div`

--- a/src/components/HeaderBar.jsx
+++ b/src/components/HeaderBar.jsx
@@ -40,7 +40,7 @@ const ContentContainer = styled.div`
 	justify-content: center;
 `;
 
-const HeaderBrand = styled.div`
+const HeaderBrand = styled.a`
 	cursor: pointer;
 	user-select: none;
 	display: flex;

--- a/src/components/HomeContents/BackgroundContents.jsx
+++ b/src/components/HomeContents/BackgroundContents.jsx
@@ -5,7 +5,7 @@ import CircleStyle from '../../style/CircleStyle';
 const BackgroundContainer = styled.div`
 	opacity: 0;
 	animation: ${fadeIn} 0.5s ease-in-out forwards;
-	z-index: 1;
+	z-index: 0;
 `;
 
 function BackgroundContents() {

--- a/src/components/HowToPageContents/HowTo.jsx
+++ b/src/components/HowToPageContents/HowTo.jsx
@@ -11,9 +11,11 @@ import picImage1 from '../../img/Pic1.png';
 import picImage2 from '../../img/Pic2.png';
 
 const Container = styled.div`
+	position: relative;
 	width: 100%;
 	height: 100%;
 	overflow: auto;
+	z-index: 1;
 `;
 
 const SubContainer = styled.div`
@@ -38,7 +40,6 @@ const HeaderContainer = styled.header`
 	align-self: flex-start;
 	padding-top: 50px;
 	text-align: center;
-	z-index: 3;
 `;
 
 const Title = styled.h1`
@@ -55,7 +56,6 @@ const Section = styled.div`
 	flex-direction: column;
 	align-items: center;
 	text-align: center;
-	z-index: 3;
 `;
 
 const Step = styled.h2`

--- a/src/pages/AboutKumap.jsx
+++ b/src/pages/AboutKumap.jsx
@@ -16,9 +16,11 @@ const Container = styled.div`
 `;
 
 const ContentsContainer = styled.div`
+	position: relative;
 	width: 100%;
 	height: 100%;
 	overflow-y: auto;
+	z-index: 1;
 `;
 
 const SubContainer = styled.div`
@@ -35,7 +37,6 @@ const LastContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	z-index: 3;
 `;
 
 const AboutKumap = () => {

--- a/src/pages/AboutUs.jsx
+++ b/src/pages/AboutUs.jsx
@@ -13,9 +13,11 @@ const Container = styled.div`
 `;
 
 const ContentsContainer = styled.div`
+	position: relative;
 	width: 100%;
 	height: 100%;
 	overflow-y: auto;
+	z-index: 1;
 `;
 
 const AboutUs = () => {


### PR DESCRIPTION
## 구현 사항

- 배경 원에 커서를 올리면 스크롤이 되지 않던 이슈를 해결하였습니다.
- 건국대학교 로고를 클릭해도 컨국대학교 홈페이지로 이동하지 않는 이슈를 해결하였습니다.

## 🚀 로직 설명 및 코드 설명

- 컴포넌트의 z-index를 전체적으로 수정하여 배경은 -1, 중요한 컴포넌트만 1 또는 2의 값을 가지도록 수정하여 배경 컴포넌트가 다른 컴포넌트 위에 레이어 되지 않도록 수정하였습니다.
- HeaderBrand가 a 태그로 렌더링되지 않을 경우, 클릭해도 링크가 작동하지 않을 수 있습니다. 따라서 div 였던 태그를 a 로 수정하였습니다.

## 연관된 이슈

- 모니터의 크기가 달려져도 최대한 일정한 화면을 출력하도록 수정하고 있습니다.
- 이미지를 효율적으로 출력하는 방법에 대해 고민하고 있습니다.
- 로드맵 로직을 분리 시키는 작업은 추후에 진행하도록 하겠습니다.

## 🤔고민 사항

- 적고싶은 고민 사항이 있다면 추가해주세요
