### PR TITLE
[Refactor] 검색 기능 리팩토링

### DIFF
--- a/src/components/FieldSearchBar/FieldGridContents.jsx
+++ b/src/components/FieldSearchBar/FieldGridContents.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Color } from '@styles';
+
+const GridContainer = styled.div`
+	height: ${({ $isMiddleGrid }) => ($isMiddleGrid ? '95%' : '')};
+	display: grid;
+	grid-template-columns: repeat(${({ $columnCount }) => $columnCount || '4'}, 1fr);
+	border: ${({ $isMiddleGrid }) => ($isMiddleGrid ? `0.2px solid ${Color.LIGHT_GREY}` : 'none')};
+	border-radius: 4px;
+	grid-gap: ${({ $isMiddleGrid }) => ($isMiddleGrid ? '' : '10px')};
+`;
+
+const FieldItem = styled.div.attrs(({ $selectedField, $isDetailField }) => ({
+	id: $isDetailField
+		? `field_name_${$selectedField.middleField} > ${$selectedField.smallField} > ${$selectedField.detailField} - field_code_${$selectedField.detailFieldCode}`
+		: ''
+}))`
+	display: flex;
+	align-items: center;
+	width: 90%;
+	padding: 8px;
+	font-size: 14px;
+	cursor: pointer;
+	background: ${({ $isSelected }) => ($isSelected ? Color.HOVER_GREEN : 'white')};
+	color: ${({ $isSelected }) => ($isSelected ? Color.GREEN : Color.BLACK)};
+
+	&:hover {
+		background-color: ${Color.HOVER_GREEN};
+	}
+`;
+
+const fieldStyleProps = (field, type, selectedField, fieldsRef) => {
+	if (type === 'detail') {
+		return {
+			displayText: field.detailField,
+			isDetailField: true,
+			refSetter: (el) => (fieldsRef.detail.current[field.detailField] = el),
+			isSelected: selectedField.detailField && selectedField.detailField.detailField === field.detailField
+		};
+	}
+
+	return {
+		displayText: field.smallField,
+		isDetailField: false,
+		refSetter: (el) => (fieldsRef.small.current[field.smallField] = el),
+		isSelected: false
+	};
+};
+
+const FieldGridContents = ({ type, fieldsData, clickHandler, fieldsRef, selectedField }) => {
+	return (
+		<GridContainer>
+			{fieldsData.map((field, index) => {
+				const { displayText, refSetter, isSelected, isDetailField } = fieldStyleProps(
+					field,
+					type,
+					selectedField,
+					fieldsRef
+				);
+
+				return (
+					<FieldItem
+						key={index}
+						$selectedField={field}
+						$isDetailField={isDetailField}
+						onClick={() => clickHandler(field)}
+						$isSelected={isSelected}
+						ref={refSetter}
+					>
+						{displayText}
+					</FieldItem>
+				);
+			})}
+		</GridContainer>
+	);
+};
+
+FieldGridContents.displayName = 'FieldGridContents';
+
+export default FieldGridContents;

--- a/src/components/FieldSearchBar/FieldGridContents.jsx
+++ b/src/components/FieldSearchBar/FieldGridContents.jsx
@@ -3,12 +3,10 @@ import styled from 'styled-components';
 import { Color } from '@styles';
 
 const GridContainer = styled.div`
-	height: ${({ $isMiddleGrid }) => ($isMiddleGrid ? '95%' : '')};
 	display: grid;
 	grid-template-columns: repeat(${({ $columnCount }) => $columnCount || '4'}, 1fr);
-	border: ${({ $isMiddleGrid }) => ($isMiddleGrid ? `0.2px solid ${Color.LIGHT_GREY}` : 'none')};
 	border-radius: 4px;
-	grid-gap: ${({ $isMiddleGrid }) => ($isMiddleGrid ? '' : '10px')};
+	grid-gap: 10px;
 `;
 
 const FieldItem = styled.div.attrs(({ $selectedField, $isDetailField }) => ({

--- a/src/components/FieldSearchBar/FieldInput.jsx
+++ b/src/components/FieldSearchBar/FieldInput.jsx
@@ -5,10 +5,10 @@ import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import {
 	detailFieldState,
 	middleFieldState,
-	selectedFieldLogState,
 	selectedFieldState,
 	smallFieldState,
-	selectedSubjectState
+	selectedSubjectState,
+	selectedFieldLogSelector
 } from '@recoils';
 import { Color, fadeIn } from '@styles';
 import useAtomReducer from '@recoils/useAtomReducer';
@@ -104,8 +104,9 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 	const smallFields = useRecoilValue(smallFieldState);
 	const detailFields = useRecoilValue(detailFieldState);
 
+	const setFieldLog = useSetRecoilState(selectedFieldLogSelector);
+
 	const selectedField = useRecoilValue(selectedFieldState);
-	const setSelectedFieldLog = useSetRecoilState(selectedFieldLogState);
 	const resetSelectedSubjectState = useResetRecoilState(selectedSubjectState);
 
 	const { dispatch } = useAtomReducer();
@@ -147,20 +148,7 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 		};
 
 		dispatch({ type: 'clickDetail', field });
-
-		setSelectedFieldLog((prevState) => {
-			const isDuplicate = prevState.some(
-				(item) => item.detailField.detailFieldCode === updatedFieldCodeList.detailField.detailFieldCode
-			);
-
-			if (isDuplicate) return prevState;
-
-			const newLog = [...prevState, updatedFieldCodeList];
-			if (newLog.length > 5) {
-				newLog.shift();
-			}
-			return newLog;
-		});
+		setFieldLog(updatedFieldCodeList);
 
 		resetSelectedSubjectState();
 		fetchSubjectsInField(field.detailFieldCode);

--- a/src/components/FieldSearchBar/FieldInput.jsx
+++ b/src/components/FieldSearchBar/FieldInput.jsx
@@ -12,6 +12,7 @@ import {
 } from '@recoils';
 import { Color, fadeIn } from '@styles';
 import useAtomReducer from '@recoils/useAtomReducer';
+import { FieldListContents } from '.';
 
 const FieldInputContainer = styled.div`
 	width: 95%;
@@ -48,14 +49,6 @@ const GridContainer = styled.div`
 	border: ${({ $isMiddleGrid }) => ($isMiddleGrid ? `0.2px solid ${Color.LIGHT_GREY}` : 'none')};
 	border-radius: 4px;
 	grid-gap: ${({ $isMiddleGrid }) => ($isMiddleGrid ? '' : '10px')};
-`;
-
-const ListContainer = styled.div`
-	width: 100%;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 8px;
 `;
 
 const FieldItem = styled.div.attrs(({ $selectedField, $isDetailField }) => ({
@@ -163,18 +156,13 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 					$isShowFieldColumn={!!selectedField.middleField || !selectedField.smallField}
 				>
 					{selectedField.middleField ? (
-						<ListContainer>
-							{middleFields.map((field, index) => (
-								<FieldItem
-									key={index}
-									onClick={() => handleMiddleFieldClick(field)}
-									$isSelected={selectedField.middleField?.middleField === field.middleField}
-									ref={(el) => (fieldRefs.middle.current[field.middleField] = el)}
-								>
-									{field.middleField}
-								</FieldItem>
-							))}
-						</ListContainer>
+						<FieldListContents
+							type="middle"
+							selectedField={selectedField}
+							fieldsData={middleFields}
+							clickHandler={handleMiddleFieldClick}
+							fieldsRef={fieldRefs}
+						/>
 					) : (
 						<GridContainer $isMiddleGrid={true}>
 							{middleFields.map((field, index) => (
@@ -197,19 +185,13 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 					$showBorder={selectedField.middleField}
 				>
 					{selectedField.smallField ? (
-						<ListContainer>
-							{smallFields.map((field, index) => (
-								<FieldItem
-									key={index}
-									onClick={() => handleSmallFieldClick(field)}
-									$isSelected={selectedField.smallField?.smallField === field.smallField}
-									ref={(el) => (fieldRefs.small.current[field.smallField] = el)}
-									$isList={selectedField.smallField}
-								>
-									{field.smallField}
-								</FieldItem>
-							))}
-						</ListContainer>
+						<FieldListContents
+							type="small"
+							selectedField={selectedField}
+							fieldsData={smallFields}
+							clickHandler={handleSmallFieldClick}
+							fieldsRef={fieldRefs}
+						/>
 					) : (
 						<GridContainer>
 							{smallFields.map((field, index) => (

--- a/src/components/FieldSearchBar/FieldInput.jsx
+++ b/src/components/FieldSearchBar/FieldInput.jsx
@@ -43,13 +43,12 @@ const FieldColumn = styled.div`
 	display: ${({ $isShowFieldColumn }) => ($isShowFieldColumn ? 'block' : 'none')};
 `;
 
-const GridContainer = styled.div`
-	height: ${({ $isMiddleGrid }) => ($isMiddleGrid ? '95%' : '')};
+const MiddleGridContainer = styled.div`
+	height: 95%;
 	display: grid;
 	grid-template-columns: repeat(${({ $columnCount }) => $columnCount || '4'}, 1fr);
-	border: ${({ $isMiddleGrid }) => ($isMiddleGrid ? `0.2px solid ${Color.LIGHT_GREY}` : 'none')};
+	border: 0.2px solid ${Color.LIGHT_GREY};
 	border-radius: 4px;
-	grid-gap: ${({ $isMiddleGrid }) => ($isMiddleGrid ? '' : '10px')};
 `;
 
 const MiddleGridItem = styled.div`
@@ -146,7 +145,7 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 							fieldsRef={fieldRefs}
 						/>
 					) : (
-						<GridContainer $isMiddleGrid={true}>
+						<MiddleGridContainer $isMiddleGrid={true}>
 							{middleFields.map((field, index) => (
 								<MiddleGridItem
 									key={index}
@@ -157,7 +156,7 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 									{field.middleField}
 								</MiddleGridItem>
 							))}
-						</GridContainer>
+						</MiddleGridContainer>
 					)}
 				</FieldColumn>
 

--- a/src/components/FieldSearchBar/FieldInput.jsx
+++ b/src/components/FieldSearchBar/FieldInput.jsx
@@ -1,17 +1,17 @@
 import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import useField from '@hooks/useField';
-import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import {
 	detailFieldState,
 	middleFieldState,
 	selectedFieldLogState,
 	selectedFieldState,
 	smallFieldState,
-	selectedSubjectState,
-	subjectsInFieldState
+	selectedSubjectState
 } from '@recoils';
 import { Color, fadeIn } from '@styles';
+import useAtomReducer from '@recoils/useAtomReducer';
 
 const FieldInputContainer = styled.div`
 	width: 95%;
@@ -104,10 +104,11 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 	const smallFields = useRecoilValue(smallFieldState);
 	const detailFields = useRecoilValue(detailFieldState);
 
-	const [selectedField, setSelectedField] = useRecoilState(selectedFieldState);
+	const selectedField = useRecoilValue(selectedFieldState);
 	const setSelectedFieldLog = useSetRecoilState(selectedFieldLogState);
-	const setSubjectsInField = useSetRecoilState(subjectsInFieldState);
 	const resetSelectedSubjectState = useResetRecoilState(selectedSubjectState);
+
+	const { dispatch } = useAtomReducer();
 
 	const fieldRefs = {
 		middle: useRef({}),
@@ -127,22 +128,17 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 		}
 	}, [selectedField]);
 
-	const handleMiddleFieldClick = async (field) => {
-		await fetchSmallField(field);
-		setSelectedField({ middleField: field });
-		setSubjectsInField([]);
+	const handleMiddleFieldClick = (field) => {
+		fetchSmallField(field);
+		dispatch({ type: 'clickMiddle', field });
 	};
 
-	const handleSmallFieldClick = async (field) => {
-		await fetchDetailField(field);
-		setSelectedField((prevState) => ({
-			...prevState,
-			smallField: field
-		}));
-		setSubjectsInField([]);
+	const handleSmallFieldClick = (field) => {
+		fetchDetailField(field);
+		dispatch({ type: 'clickSmall', field });
 	};
 
-	const handleDetailFieldClick = async (field) => {
+	const handleDetailFieldClick = (field) => {
 		if (selectedField?.detailField?.detailFieldCode === field.detailFieldCode) return;
 
 		const updatedFieldCodeList = {
@@ -150,7 +146,8 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 			detailField: field
 		};
 
-		setSelectedField(updatedFieldCodeList);
+		dispatch({ type: 'clickDetail', field });
+
 		setSelectedFieldLog((prevState) => {
 			const isDuplicate = prevState.some(
 				(item) => item.detailField.detailFieldCode === updatedFieldCodeList.detailField.detailFieldCode
@@ -166,8 +163,8 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 		});
 
 		resetSelectedSubjectState();
-		await fetchSubjectsInField(field.detailFieldCode);
-		await fetchCoursesInFields(field.detailFieldCode);
+		fetchSubjectsInField(field.detailFieldCode);
+		fetchCoursesInFields(field.detailFieldCode);
 
 		showHandler(true);
 	};

--- a/src/components/FieldSearchBar/FieldInput.jsx
+++ b/src/components/FieldSearchBar/FieldInput.jsx
@@ -98,8 +98,7 @@ export const scrollOption = {
 };
 
 const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
-	const { fetchMiddleField, fetchSmallField, fetchDetailField, fetchSubjectsInField, fetchCoursesInFields } =
-		useField();
+	const { fetchMiddleField, fetchSmallField, fetchDetailField, fetchSubjectsAndCourses } = useField();
 	const middleFields = useRecoilValue(middleFieldState);
 	const smallFields = useRecoilValue(smallFieldState);
 	const detailFields = useRecoilValue(detailFieldState);
@@ -151,8 +150,7 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 		setFieldLog(updatedFieldCodeList);
 
 		resetSelectedSubjectState();
-		fetchSubjectsInField(field.detailFieldCode);
-		fetchCoursesInFields(field.detailFieldCode);
+		fetchSubjectsAndCourses(field.detailFieldCode);
 
 		showHandler(true);
 	};

--- a/src/components/FieldSearchBar/FieldInput.jsx
+++ b/src/components/FieldSearchBar/FieldInput.jsx
@@ -13,6 +13,7 @@ import {
 import { Color, fadeIn } from '@styles';
 import useAtomReducer from '@recoils/useAtomReducer';
 import { FieldListContents } from '.';
+import FieldGridContents from './FieldGridContents';
 
 const FieldInputContainer = styled.div`
 	width: 95%;
@@ -49,25 +50,6 @@ const GridContainer = styled.div`
 	border: ${({ $isMiddleGrid }) => ($isMiddleGrid ? `0.2px solid ${Color.LIGHT_GREY}` : 'none')};
 	border-radius: 4px;
 	grid-gap: ${({ $isMiddleGrid }) => ($isMiddleGrid ? '' : '10px')};
-`;
-
-const FieldItem = styled.div.attrs(({ $selectedField, $isDetailField }) => ({
-	id: $isDetailField
-		? `field_name_${$selectedField.middleField} > ${$selectedField.smallField} > ${$selectedField.detailField} - field_code_${$selectedField.detailFieldCode}`
-		: ''
-}))`
-	display: flex;
-	align-items: center;
-	width: 90%;
-	padding: 8px;
-	font-size: 14px;
-	cursor: pointer;
-	background: ${({ $isSelected }) => ($isSelected ? Color.HOVER_GREEN : 'white')};
-	color: ${({ $isSelected }) => ($isSelected ? Color.GREEN : Color.BLACK)};
-
-	&:hover {
-		background-color: ${Color.HOVER_GREEN};
-	}
 `;
 
 const MiddleGridItem = styled.div`
@@ -193,38 +175,24 @@ const FieldInput = ({ showHandler, isShowDepartAndLog }) => {
 							fieldsRef={fieldRefs}
 						/>
 					) : (
-						<GridContainer>
-							{smallFields.map((field, index) => (
-								<FieldItem
-									key={index}
-									onClick={() => handleSmallFieldClick(field)}
-									$isSelected={selectedField.smallField?.smallField === field.smallField}
-									ref={(el) => (fieldRefs.small.current[field.smallField] = el)}
-									$isList={selectedField.smallField}
-								>
-									{field.smallField}
-								</FieldItem>
-							))}
-						</GridContainer>
+						<FieldGridContents
+							type="small"
+							fieldsData={smallFields}
+							clickHandler={handleSmallFieldClick}
+							fieldsRef={fieldRefs}
+							selectedField={selectedField}
+						/>
 					)}
 				</FieldColumn>
 
 				<FieldColumn $width="60%" $isShowFieldColumn={selectedField.smallField} $showBorder={selectedField.smallField}>
-					<GridContainer>
-						{detailFields.map((field, index) => (
-							<FieldItem
-								key={index}
-								$selectedField={field}
-								$isDetailField={field.detailField}
-								onClick={() => handleDetailFieldClick(field)}
-								$isSelected={selectedField.detailField?.detailField === field.detailField}
-								ref={(el) => (fieldRefs.detail.current[field.detailField] = el)}
-								$isList={!selectedField.smallField}
-							>
-								{field.detailField}
-							</FieldItem>
-						))}
-					</GridContainer>
+					<FieldGridContents
+						type="detail"
+						fieldsData={detailFields}
+						clickHandler={handleDetailFieldClick}
+						fieldsRef={fieldRefs}
+						selectedField={selectedField}
+					/>
 				</FieldColumn>
 			</FieldInputContentsContainer>
 		</FieldInputContainer>

--- a/src/components/FieldSearchBar/FieldListContents.jsx
+++ b/src/components/FieldSearchBar/FieldListContents.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Color } from '@styles';
+
+const ListContainer = styled.div`
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+`;
+
+const FieldItem = styled.div.attrs(({ $selectedField, $isDetailField }) => ({
+	id: $isDetailField
+		? `field_name_${$selectedField.middleField} > ${$selectedField.smallField} > ${$selectedField.detailField} - field_code_${$selectedField.detailFieldCode}`
+		: ''
+}))`
+	display: flex;
+	align-items: center;
+	width: 90%;
+	padding: 8px;
+	font-size: 14px;
+	cursor: pointer;
+	background: ${({ $isSelected }) => ($isSelected ? Color.HOVER_GREEN : 'white')};
+	color: ${({ $isSelected }) => ($isSelected ? Color.GREEN : Color.BLACK)};
+
+	&:hover {
+		background-color: ${Color.HOVER_GREEN};
+	}
+`;
+
+const fieldStyleProps = (field, type, selectedField, fieldsRef) => {
+	if (type === 'middle') {
+		return {
+			isSelected: selectedField.middleField?.middleField === field.middleField,
+			refSetter: (el) => (fieldsRef.middle.current[field.middleField] = el),
+			displayText: field.middleField
+		};
+	}
+
+	return {
+		isSelected: selectedField.smallField?.smallField === field.smallField,
+		refSetter: (el) => (fieldsRef.small.current[field.smallField] = el),
+		displayText: field.smallField
+	};
+};
+
+const FieldListContents = React.forwardRef(({ type, selectedField, fieldsData, clickHandler, fieldsRef }, ref) => {
+	return (
+		<ListContainer ref={ref}>
+			{fieldsData.map((field, index) => {
+				const { isSelected, refSetter, displayText } = fieldStyleProps(field, type, selectedField, fieldsRef);
+
+				return (
+					<FieldItem key={index} onClick={() => clickHandler(field)} $isSelected={isSelected} ref={refSetter}>
+						{displayText}
+					</FieldItem>
+				);
+			})}
+		</ListContainer>
+	);
+});
+
+FieldListContents.displayName = 'FieldListContents';
+
+export default FieldListContents;

--- a/src/components/FieldSearchBar/FieldListContents.jsx
+++ b/src/components/FieldSearchBar/FieldListContents.jsx
@@ -10,11 +10,7 @@ const ListContainer = styled.div`
 	gap: 8px;
 `;
 
-const FieldItem = styled.div.attrs(({ $selectedField, $isDetailField }) => ({
-	id: $isDetailField
-		? `field_name_${$selectedField.middleField} > ${$selectedField.smallField} > ${$selectedField.detailField} - field_code_${$selectedField.detailFieldCode}`
-		: ''
-}))`
+const FieldItem = styled.div`
 	display: flex;
 	align-items: center;
 	width: 90%;

--- a/src/components/FieldSearchBar/SearchBar/SearchBar.jsx
+++ b/src/components/FieldSearchBar/SearchBar/SearchBar.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
 import { useField } from '@hooks';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { allFieldDataState, selectedFieldLogState, selectedFieldState } from '@recoils';
+import { allFieldDataState, selectedFieldLogSelector, selectedFieldState } from '@recoils';
 import { FaSearch, FaAngleDoubleDown, FaAngleDoubleUp } from 'react-icons/fa';
 import { Color } from '@styles';
 
@@ -105,7 +105,7 @@ const SearchBar = ({ showHandler, isToggleOn, setIsToggleOn }) => {
 	const [isFocused, setIsFocused] = useState(false);
 	const allFieldData = useRecoilValue(allFieldDataState);
 	const selectedField = useRecoilValue(selectedFieldState);
-	const setSelectedFieldLog = useSetRecoilState(selectedFieldLogState);
+	const setFieldLog = useSetRecoilState(selectedFieldLogSelector);
 	const containerRef = useRef(null);
 
 	useEffect(() => {
@@ -141,19 +141,8 @@ const SearchBar = ({ showHandler, isToggleOn, setIsToggleOn }) => {
 		};
 
 		fetchLogFields(restructuredFieldData);
-		setSelectedFieldLog((prevState) => {
-			const isDuplicate = prevState.some(
-				(item) => item.detailField.detailFieldCode === restructuredFieldData.detailField.detailFieldCode
-			);
+		setFieldLog(restructuredFieldData);
 
-			if (isDuplicate) return prevState;
-
-			const newLog = [...prevState, restructuredFieldData];
-			if (newLog.length > 5) {
-				newLog.shift();
-			}
-			return newLog;
-		});
 		setIsFocused(false);
 		showHandler(true);
 		setIsToggleOn(true);

--- a/src/components/FieldSearchBar/SearchLogContent/SearchLogContent.jsx
+++ b/src/components/FieldSearchBar/SearchLogContent/SearchLogContent.jsx
@@ -119,7 +119,7 @@ const SearchLogContent = () => {
 
 					return (
 						<LogItem key={index} onClick={() => fetchLogFields(field)}>
-							<LogText $searchField={restructuredFieldName} $selectedFieldCode={field.detailFieldCode}>
+							<LogText $searchField={restructuredFieldName} $selectedFieldCode={field.detailField.detailFieldCode}>
 								{restructuredFieldName}
 							</LogText>
 							<DeleteButton

--- a/src/components/FieldSearchBar/index.js
+++ b/src/components/FieldSearchBar/index.js
@@ -1,6 +1,7 @@
 export * from './DepartmentList';
 export { default as FieldInput } from './FieldInput';
 export { default as FieldListContents } from './FieldListContents';
+export { default as FieldGridContents } from './FieldGridContents';
 export { default as FieldSearchBar } from './FieldSearchBar';
 export * from './SearchBar';
 export * from './SearchLogContent';

--- a/src/components/FieldSearchBar/index.js
+++ b/src/components/FieldSearchBar/index.js
@@ -1,5 +1,6 @@
 export * from './DepartmentList';
 export { default as FieldInput } from './FieldInput';
+export { default as FieldListContents } from './FieldListContents';
 export { default as FieldSearchBar } from './FieldSearchBar';
 export * from './SearchBar';
 export * from './SearchLogContent';

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -124,7 +124,11 @@ const useField = () => {
 
 		fetchSmallField(middleField);
 
-		fetchDetailField(smallField);
+		fetchDetailField({
+			middleField: middleField.middleField,
+			...smallField
+		});
+
 		setSelectedFieldState({
 			middleField,
 			smallField,

--- a/src/hooks/useField.jsx
+++ b/src/hooks/useField.jsx
@@ -60,14 +60,7 @@ const useField = () => {
 	};
 
 	const fetchSubjectsInField = (detailFieldCode) => {
-		serverApi
-			.get(`/api/v1/fields/${detailFieldCode}/subjects`)
-			.then((res) => {
-				setSubjectsInFieldState(res.data);
-			})
-			.catch((error) => {
-				console.error(error);
-			});
+		return serverApi.get(`/api/v1/fields/${detailFieldCode}/subjects`);
 	};
 
 	const fetchCoursesInFieldsAndSubjects = (fieldCode, subjectCode) => {
@@ -82,14 +75,7 @@ const useField = () => {
 	};
 
 	const fetchCoursesInFields = (fieldCode) => {
-		serverApi
-			.get(`/api/v1/courses/${fieldCode}/field`)
-			.then((res) => {
-				setCourseByCompetencyInSubjectState(res.data);
-			})
-			.catch((error) => {
-				console.error(error);
-			});
+		return serverApi.get(`/api/v1/courses/${fieldCode}/field`);
 	};
 
 	const fetchCoursesInSubject = (subjectCode) => {
@@ -133,29 +119,28 @@ const useField = () => {
 			});
 	};
 
-	const fetchLogFields = async ({ middleField, smallField, detailField }) => {
-		try {
-			resetSelectedSubjectState();
+	const fetchLogFields = ({ middleField, smallField, detailField }) => {
+		resetSelectedSubjectState();
 
-			const smallFieldResponse = await serverApi.post('/api/v2/field-search/small', middleField);
-			setSmallFieldState(smallFieldResponse.data);
+		fetchSmallField(middleField);
 
-			const detailFieldResponse = await serverApi.post('/api/v2/field-search/detail', smallField);
-			setDetailFieldState(detailFieldResponse.data);
-			setSelectedFieldState({
-				middleField,
-				smallField,
-				detailField
-			});
+		fetchDetailField(smallField);
+		setSelectedFieldState({
+			middleField,
+			smallField,
+			detailField
+		});
 
-			const [subjectsResponse] = await Promise.all([
-				serverApi.get(`/api/v1/fields/${detailField.detailFieldCode}/subjects`),
-				fetchCoursesInFields(detailField.detailFieldCode)
-			]);
-			setSubjectsInFieldState(subjectsResponse.data);
-		} catch (error) {
-			console.error('Error fetching log fields:', error);
-		}
+		fetchSubjectsAndCourses(detailField.detailFieldCode);
+	};
+
+	const fetchSubjectsAndCourses = (detailFieldCode) => {
+		Promise.all([fetchSubjectsInField(detailFieldCode), fetchCoursesInFields(detailFieldCode)])
+			.then(([subjectRes, courseRes]) => {
+				setSubjectsInFieldState(subjectRes.data);
+				setCourseByCompetencyInSubjectState(courseRes.data);
+			})
+			.catch((error) => console.error(error));
 	};
 
 	return {
@@ -169,7 +154,8 @@ const useField = () => {
 		fetchCourseDetail,
 		fetchCompetitionRate,
 		fetchAllFields,
-		fetchLogFields
+		fetchLogFields,
+		fetchSubjectsAndCourses
 	};
 };
 

--- a/src/recoils/atoms.js
+++ b/src/recoils/atoms.js
@@ -130,3 +130,22 @@ export const selectedCompetencyState = atom({
 	key: 'selectedCompetencyState',
 	default: 'default'
 });
+
+export const selectedFieldLogSelector = selector({
+	key: 'selectedFieldLogSelector',
+	get: ({ get }) => get(selectedFieldLogState),
+	set: ({ get, set }, updatedFieldCodeList) => {
+		const prevLog = get(selectedFieldLogState);
+		const isDuplicate = prevLog.some(
+			(item) => item.detailField.detailFieldCode === updatedFieldCodeList.detailField.detailFieldCode
+		);
+
+		if (isDuplicate) return;
+
+		const newLog = [...prevLog, updatedFieldCodeList];
+		if (newLog.length > 5) {
+			newLog.shift();
+		}
+		set(selectedFieldLogState, newLog);
+	}
+});

--- a/src/recoils/useAtomReducer.jsx
+++ b/src/recoils/useAtomReducer.jsx
@@ -1,0 +1,34 @@
+import { useRecoilTransaction_UNSTABLE } from 'recoil';
+import { selectedFieldState, subjectsInFieldState } from './atoms';
+
+function useAtomActionDispatcher() {
+	const dispatch = useRecoilTransaction_UNSTABLE(({ set }) => (action) => {
+		switch (action.type) {
+			case 'clickMiddle':
+				set(selectedFieldState, { middleField: action.field });
+				set(subjectsInFieldState, []);
+				break;
+
+			case 'clickSmall':
+				set(selectedFieldState, (prevState) => ({
+					...prevState,
+					smallField: action.field
+				}));
+				set(subjectsInFieldState, []);
+				break;
+
+			case 'clickDetail':
+				set(selectedFieldState, (prevState) => ({
+					...prevState,
+					detailField: action.field
+				}));
+				break;
+
+			default:
+				break;
+		}
+	});
+	return { dispatch };
+}
+
+export default useAtomActionDispatcher;

--- a/src/recoils/useAtomReducer.jsx
+++ b/src/recoils/useAtomReducer.jsx
@@ -1,33 +1,35 @@
-import { useRecoilTransaction_UNSTABLE } from 'recoil';
+import { useRecoilCallback } from 'recoil';
 import { selectedFieldState, subjectsInFieldState } from './atoms';
 
 function useAtomActionDispatcher() {
-	const dispatch = useRecoilTransaction_UNSTABLE(({ set }) => (action) => {
-		switch (action.type) {
-			case 'clickMiddle':
-				set(selectedFieldState, { middleField: action.field });
-				set(subjectsInFieldState, []);
-				break;
+	const dispatch = useRecoilCallback(
+		({ set }) =>
+			(action) => {
+				switch (action.type) {
+					case 'clickMiddle':
+						set(selectedFieldState, { middleField: action.field });
+						set(subjectsInFieldState, []);
+						break;
+					case 'clickSmall':
+						set(selectedFieldState, (prevState) => ({
+							...prevState,
+							smallField: action.field
+						}));
+						set(subjectsInFieldState, []);
+						break;
+					case 'clickDetail':
+						set(selectedFieldState, (prevState) => ({
+							...prevState,
+							detailField: action.field
+						}));
+						break;
+					default:
+						break;
+				}
+			},
+		[]
+	);
 
-			case 'clickSmall':
-				set(selectedFieldState, (prevState) => ({
-					...prevState,
-					smallField: action.field
-				}));
-				set(subjectsInFieldState, []);
-				break;
-
-			case 'clickDetail':
-				set(selectedFieldState, (prevState) => ({
-					...prevState,
-					detailField: action.field
-				}));
-				break;
-
-			default:
-				break;
-		}
-	});
 	return { dispatch };
 }
 


### PR DESCRIPTION
## 구현 사항

### 1. useRecoilCallback을 이용하여 dispatcher 구현

### BEFORE
```js
const handleMiddleFieldClick = async (field) => {
	await fetchSmallField(field);
	setSelectedField({ middleField: field });
	setSubjectsInField([]);
};
```

### AFTER
```js
// dispatch 구현
const dispatch = useRecoilCallback(
	({ set }) =>
		(action) => {
			switch (action.type) {
				case 'clickMiddle':
					set(selectedFieldState, { middleField: action.field });
					set(subjectsInFieldState, []);
					break;

				default:
					break;
			}
		},
	[]
);



// 실제 사용처
const handleMiddleFieldClick = (field) => {
	fetchSmallField(field);
	dispatch({ type: 'clickMiddle', field });
};
```
- dispatcher 구현을 통해 코드의 모듈화 및 일관성을 유지하고자 했습니다.
- 비동기 작업과 상태 업데이트를 깔끔하게 분리했습니다.

### 2. selector를 통해 검색 로그에 대한 캡슐화를 적용
```js
export const selectedFieldLogSelector = selector({
	key: 'selectedFieldLogSelector',
	get: ({ get }) => get(selectedFieldLogState),
	set: ({ get, set }, updatedFieldCodeList) => {
		const prevLog = get(selectedFieldLogState);
		const isDuplicate = prevLog.some(
			(item) => item.detailField.detailFieldCode === updatedFieldCodeList.detailField.detailFieldCode
		);

		if (isDuplicate) return;

		const newLog = [...prevLog, updatedFieldCodeList];
		if (newLog.length > 5) {
			newLog.shift();
		}
		set(selectedFieldLogState, newLog);
	}
});
```
- 상태 업데이트 로직(중복 체크, 최대 로그 길이 제한)을 selector 내부에 캡슐화하여, 컴포넌트에서는 단순히 값을 읽거나 업데이트만 하면 되도록 개선했습니다.

### 3. FieldContent 컴포넌트로 분리
### BEFORE
```js
{selectedField.smallField ? (
	<ListContainer>
		{smallFields.map((field, index) => (
			<FieldItem
				key={index}
				onClick={() => handleSmallFieldClick(field)}
				$isSelected={selectedField.smallField?.smallField === field.smallField}
				ref={(el) => (fieldRefs.small.current[field.smallField] = el)}
				$isList={selectedField.smallField}
			>
				{field.smallField}
			</FieldItem>
		))}
	</ListContainer>
) : (
	<GridContainer>
		{smallFields.map((field, index) => (
			<FieldItem
				key={index}
				onClick={() => handleSmallFieldClick(field)}
				$isSelected={selectedField.smallField?.smallField === field.smallField}
				ref={(el) => (fieldRefs.small.current[field.smallField] = el)}
				$isList={selectedField.smallField}
			>
				{field.smallField}
			</FieldItem>
		))}
	</GridContainer>
)}
```

### AFTER
```js
{selectedField.smallField ? (
	<FieldListContents
		type="small"
		selectedField={selectedField}
		fieldsData={smallFields}
		clickHandler={handleSmallFieldClick}
		fieldsRef={fieldRefs}
	/>
) : (
	<FieldGridContents
		type="small"
		fieldsData={smallFields}
		clickHandler={handleSmallFieldClick}
		fieldsRef={fieldRefs}
		selectedField={selectedField}
	/>
)}
```
- FieldContent의 렌더링 로직을 별도의 컴포넌트(FieldListContents, FieldGridContents)로 분리하여 코드의 재사용성을 높이고, 컴포넌트 내 책임을 명확히 했습니다.
- UI 분기를 보다 깔끔하게 관리할 수 있게 되어, 향후 스타일 변경이나 기능 확장이 용이해졌습니다.


## 🤔고민 사항
- 이번에 recoil의 selector를 공부하면서, 비동기 처리를 할 때 selector를 이용하면 캐싱할 수 있다는 사실을 알았습니다. 추후에 필요한 곳에 적용해보면 좋을 것 같습니다.
- 이전 PR에서 언급된 문제점들을 모두 해결했습니다. (검색창으로 검색 시 중분류가 null이 됨, 검색기록으로 검색 시 직군코드 undefined)

### BEFORE

https://github.com/user-attachments/assets/d4f8e037-7152-4b29-b7f7-834d3b3cccef



### AFTER

https://github.com/user-attachments/assets/5999c9fc-2e18-43cc-a9b1-c68f02742e38

- 검색바를 이용해 검색한 뒤, 다른 세분류 직군을 클릭하면 중분류가 'null'로 기록되는 이슈를 해결했습니다.
- fetchDetail의 payLoad 중에 누락된 요소가 존재하여 추가했습니다.
```js
fetchDetailField({
	middleField: middleField.middleField,
	...smallField
});
```

